### PR TITLE
fix: edicion de la palabra "Artículo" de capítulos 5 al 11

### DIFF
--- a/Markdown/.ipynb_checkpoints/11-checkpoint.md
+++ b/Markdown/.ipynb_checkpoints/11-checkpoint.md
@@ -8,7 +8,7 @@
 4. Todo proyecto de reforma constitucional deberá señalar expresamente de qué forma se agrega, modifica, reemplaza o deroga una norma de la Constitución.
 5. En lo no previsto en este capítulo, serán aplicables a la tramitación de los proyectos de reforma constitucional las disposiciones que regulan el procedimiento de formación de la ley, debiendo respetarse siempre el quorum señalado en este artículo.
 
-### Artículo 384
+### Artículo 384
 
 1. La Presidenta o el Presidente de la República deberá convocar a referéndum ratificatorio tratándose de proyectos de reforma constitucional aprobados por el Congreso de Diputadas y Diputados y la Cámara de las Regiones, que alteren sustancialmente el régimen político y el período presidencial; el diseño del Congreso de Diputadas y Diputados o de la Cámara de las Regiones y la duración de sus integrantes; la forma de Estado Regional; los principios y los derechos fundamentales; y el capítulo de reforma y reemplazo de la Constitución.
 2. Si el proyecto de reforma constitucional es aprobado por dos tercios de diputadas y diputados y representantes regionales en ejercicio, no será sometido a referéndum ratificatorio.
@@ -17,7 +17,7 @@
 5. La reforma constitucional aprobada por el Congreso de Diputadas y Diputados y la Cámara de las Regiones se entenderá ratificada si alcanza la mayoría de los votos válidamente emitidos en el referéndum.
 6. Es deber del Estado dar adecuada publicidad a la propuesta de reforma que se someterá a referéndum, de acuerdo con la Constitución y la ley.
 
-### Artículo 385
+### Artículo 385
 
 1. Un mínimo equivalente al diez por ciento de la ciudadanía correspondiente al último padrón electoral podrá presentar una propuesta de reforma constitucional para ser votada mediante referéndum nacional conjuntamente con la próxima elección.
 2. Existirá un plazo de ciento ochenta días desde su registro para que la propuesta sea conocida por la ciudadanía y pueda reunir los patrocinios exigidos.
@@ -26,7 +26,7 @@
 
 ## Procedimiento para elaborar una nueva Constitución
 
-### Artículo 386
+### Artículo 386
 
 1. El reemplazo total de la Constitución solo podrá realizarse a través de una Asamblea Constituyente convocada por medio de un referéndum.
 2. El referéndum constituyente podrá ser convocado por iniciativa popular. Un grupo de personas con derecho a sufragio deberá patrocinar la convocatoria con, a lo menos, firmas correspondientes al veinticinco por ciento del padrón electoral que haya sido establecido para la última elección.
@@ -34,13 +34,13 @@
 4. Asimismo, la convocatoria corresponderá al Congreso de Diputadas y Diputados y la Cámara de las Regiones, en sesión conjunta, por medio de una ley aprobada por los dos tercios de sus integrantes en ejercicio.
 5. La convocatoria para la instalación de la Asamblea Constituyente será aprobada si en el referéndum es votada favorablemente por la mayoría de los votos válidamente emitidos.
 
-### Artículo 387
+### Artículo 387
 
 1. La Asamblea Constituyente tendrá como única función la redacción de una propuesta de nueva Constitución. Estará integrada paritariamente y con equidad territorial, con participación en igualdad de condiciones entre independientes e integrantes de partidos políticos y con escaños reservados para pueblos y naciones indígenas.
 2. Una ley regulará su integración; el sistema de elección; su duración, que no será inferior a dieciocho meses; su organización mínima; los mecanismos de participación popular y consulta indígena del proceso, y demás aspectos generales que permitan su instalación y funcionamiento regular.
 3. Una vez redactada y entregada la propuesta de nueva Constitución a la autoridad competente, la Asamblea Constituyente se disolverá de pleno derecho.
 
-### Artículo 388
+### Artículo 388
 
 1. Entregada la propuesta de nueva Constitución, deberá convocarse a un referéndum para su aprobación o rechazo. Para que la propuesta sea aprobada, deberá obtener el voto favorable de más de la mitad de los sufragios válidamente emitidos.
 2. Si la propuesta de nueva Constitución fuera aprobada en el plebiscito, se procederá a su promulgación y correspondiente publicación.

--- a/Markdown/05 - Buen Gobierno y Función Pública.md
+++ b/Markdown/05 - Buen Gobierno y Función Pública.md
@@ -1,54 +1,54 @@
 # Capítulo V: Buen Gobierno y Función Pública
 
-### Artículo 165
+### Artículo 165
 
 1. El ejercicio de las funciones públicas obliga a sus titulares a dar cumplimiento a los principios de probidad, transparencia y rendición de cuentas en todas sus actuaciones. Además, se rige por los principios de eficiencia, eficacia, responsabilidad, publicidad, buena fe, interculturalidad, enfoque de género, inclusión, no discriminación y sustentabilidad.
 2. La función pública se deberá brindar con pertinencia territorial, cultural y lingüística.
 
-### Artículo 166
+### Artículo 166
 
 1. El principio de probidad consiste en observar una conducta funcionaria responsable e intachable, desempeñando la función o el cargo correspondiente en forma leal, honesta, objetiva e imparcial, sin incurrir en discriminaciones de ningún tipo, con preeminencia del interés general por sobre el particular.
 2. Las autoridades electas y demás autoridades, funcionarias y funcionarios que determine la ley deberán declarar sus intereses y patrimonio en forma pública. La ley regulará los casos y las condiciones en las que delegarán a terceros la administración de aquellos bienes y obligaciones que supongan un conflicto de interés en el ejercicio de la función pública. Asimismo, podrá considerar otras medidas apropiadas para resolverlos.
 
-### Artículo 167
+### Artículo 167
 
 1. La Constitución asegura a todas las personas la transparencia de la información pública facilitando su acceso de manera comprensible y oportuna, periódica, proactiva, legible y en formatos abiertos, en los plazos y condiciones que la ley establezca. El principio de transparencia exige a los órganos del Estado que la información pública sea puesta a disposición de toda persona que la requiera y procurando su oportuna entrega y accesibilidad.
 2. Es pública la información elaborada con presupuesto público y toda otra información que obre en poder o custodia del Estado, cualquiera sea su formato, soporte, fecha de creación, origen, clasificación o procesamiento.
 3. Toda institución que desarrolle una función pública o que administre recursos públicos deberá dar cumplimiento al principio de transparencia.
 4. Solo la ley puede establecer la reserva o el secreto de dicha información, por razones de seguridad del Estado o el interés nacional, protección de los derechos de las personas, datos personales o cuando su publicidad afecte el debido cumplimiento de las funciones de la respectiva institución, conforme a sus fines.
 
-### Artículo 168
+### Artículo 168
 
 Los órganos del Estado y quienes ejercen una función pública deben rendir cuenta y asumir la responsabilidad en el ejercicio de su cargo, en la forma y las condiciones que establezca la ley. El Estado promoverá la participación activa de las personas y la sociedad civil en la fiscalización del cumplimiento de este deber.
 
-### Artículo 169
+### Artículo 169
 
 1. El Consejo para la Transparencia es un órgano autónomo, especializado y objetivo con personalidad jurídica y patrimonio propio, encargado de promover la transparencia de la función pública, fiscalizar el cumplimiento de las normas sobre transparencia y publicidad de la información de los órganos del Estado y garantizar el derecho de acceso a la información pública.
 2. La ley regulará su composición, organización, funcionamiento y atribuciones.
 
-### Artículo 170
+### Artículo 170
 
 1. La corrupción es contraria al bien común y atenta contra el sistema democrático.
 2. Es deber del Estado promover la integridad de la función pública y erradicar la corrupción en todas sus formas, tanto en el sector público como en el privado. En cumplimiento de lo anterior, deberá adoptar medidas eficaces para su estudio, prevención, investigación, persecución y sanción.
 3. Los órganos competentes deberán coordinar su actuar a través de las instancias y los mecanismos que correspondan para el cumplimiento de estos fines y perseguir la aplicación de las sanciones administrativas, civiles y penales que correspondan, en la forma que determine la ley.
 
-### Artículo 171
+### Artículo 171
 
 El Estado asegura a todas las personas la debida protección, confidencialidad e indemnidad al denunciar infracciones en el ejercicio de la función pública, especialmente faltas a la probidad, transparencia y hechos de corrupción.
 
-### Artículo 172
+### Artículo 172
 
 No podrán optar a cargos públicos ni de elección popular las personas condenadas por crímenes de lesa humanidad, delitos sexuales y de violencia intrafamiliar, aquellos vinculados a corrupción como fraude al fisco, lavado de activos, soborno, cohecho, malversación de caudales públicos y los demás que así establezca la ley. Los términos y plazos de estas inhabilidades se determinarán por ley.
 
-### Artículo 173
+### Artículo 173
 
 Respecto de las altas autoridades del Estado, la ley establecerá mayores exigencias y estándares de responsabilidad para el cumplimiento de los principios de probidad, transparencia y rendición de cuentas.
 
-### Artículo 174
+### Artículo 174
 
 Una comisión fijará las remuneraciones de las autoridades de elección popular, así como de quienes sirvan de confianza exclusiva de ellas. Las remuneraciones serán fijadas cada cuatro años, con al menos dieciocho meses de anterioridad al término de un período presidencial. Los acuerdos de la comisión serán públicos, se fundarán en antecedentes técnicos y deberán garantizar una retribución adecuada a la responsabilidad del cargo. Una ley establecerá la integración, el funcionamiento y las atribuciones de esta comisión.
 
-### Artículo 175
+### Artículo 175
 
 1. La Administración pública tiene por objeto satisfacer necesidades de las personas y las comunidades. Se somete en su organización y funcionamiento a los principios de juridicidad, celeridad, objetividad, participación, control, jerarquía, buen trato y los demás principios que señalan la Constitución y la ley.
 2. Los órganos de la Administración ejecutarán políticas públicas, planes y programas y proveerán o garantizarán, en su caso, la prestación de servicios públicos en forma continua y permanente.
@@ -56,42 +56,42 @@ Una comisión fijará las remuneraciones de las autoridades de elección popu
 4. Cada autoridad y jefatura, dentro del ámbito de su competencia, podrá dictar normas, resoluciones e instrucciones para el mejor y más eficaz desarrollo de sus funciones.
 5. Cualquier persona que haya sido vulnerada en sus derechos por la Administración pública podrá reclamar ante las instancias administrativas y jurisdiccionales que establezcan esta Constitución y la ley.
 
-### Artículo 176
+### Artículo 176
 
 1. Es deber del Estado proveer de servicios públicos universales y de calidad, los cuales contarán con un financiamiento suficiente.
 2. El Estado planificará y coordinará de manera intersectorial la provisión, prestación y cobertura de estos servicios, bajo los principios de generalidad, uniformidad, regularidad y pertinencia territorial.
 
-### Artículo 177
+### Artículo 177
 
 1. La Administración pública desarrolla sus funciones propias y habituales a través de funcionarias y funcionarios públicos.
 2. Los cargos que esta Constitución o la ley califiquen como de exclusiva confianza, atendiendo a la naturaleza de sus funciones, son parte del Gobierno y tendrán el régimen de ingreso, desempeño y cesación que establezca la ley.
 3. No podrán ser nombradas en la Administración pública las personas que tengan la calidad de cónyuge, conviviente civil o parientes hasta el cuarto grado de consanguinidad y segundo de afinidad, inclusive, respecto de las autoridades y de los funcionarios directivos del organismo del Estado al que postulan. Se exceptúan los nombramientos que se hagan en aplicación de las normas vigentes sobre ingreso o ascenso por méritos en cargos de carrera.
 
-### Artículo 178
+### Artículo 178
 
 1. El Estado definirá mecanismos de modernización de sus procesos y organización; adecuará su funcionamiento a las condiciones sociales, ambientales y culturales de cada localidad; utilizará los avances de las ciencias, la tecnología, los conocimientos y la innovación para promover la optimización y mejora continua en la provisión de los bienes y servicios públicos, y destinará los recursos necesarios para esos fines. Asimismo, promoverá la participación y la gestión eficiente acorde a las necesidades de las personas y comunidades.
 2. Un organismo estará a cargo de la elaboración de planes para promover la modernización de la Administración del Estado, monitorear su implementación, elaborar diagnósticos periódicos sobre el funcionamiento de los servicios públicos y las demás funciones, conforme lo establezca la ley. Contará con un consejo consultivo cuya integración considerará, entre otros, a usuarias y usuarios y funcionarias y funcionarios de los servicios públicos y las entidades territoriales.
 
-### Artículo 179
+### Artículo 179
 
 1. El Servicio Civil está integrado por las funcionarias y los funcionarios públicos que, bajo la dirección del Gobierno, los gobiernos regionales o las municipalidades, desarrollan las funciones de la Administración pública. Se excluyen del Servicio Civil los cargos de exclusiva confianza.
 2. El ingreso a estas funciones se realizará mediante un sistema abierto, transparente, imparcial, ágil y que privilegie el mérito, la especialidad e idoneidad para el cargo, observando criterios objetivos y predeterminados.
 3. El desarrollo, la evaluación de desempeño y el cese en estas funciones deberán respetar su carácter técnico y profesional. La ley regulará las bases de la carrera funcionaria, permitiendo la movilidad de los funcionarios dentro de toda la Administración pública y la capacitación funcionaria, teniendo en cuenta la pertinencia territorial y cultural del lugar en el que se presta el servicio. Además, establecerá un sistema de formación, capacitación y perfeccionamiento de las funcionarias y los funcionarios públicos.
 
-### Artículo 180
+### Artículo 180
 
 1. La Dirección del Servicio Civil es un órgano autónomo, con personalidad jurídica y patrimonio propio, encargado del fortalecimiento de la función pública y de los procedimientos de selección de cargos en la Administración pública y demás entidades que establezcan la Constitución y la ley, resguardando los principios de transparencia, objetividad, no discriminación y mérito. Sus atribuciones no afectarán las competencias que, en el ámbito de la gestión, correspondan a las autoridades y jefaturas de los servicios públicos. La ley regulará su organización y demás atribuciones.
 2. Esta Dirección regulará los procesos de selección de candidatas y candidatos
 a cargos del Sistema de Alta Dirección Pública, o de aquellos que deben seleccionarse con su participación, y conducir los concursos destinados a proveer cargos de jefaturas superiores de servicios, a través de un Consejo de Alta Dirección Pública.
 
-### Artículo 181
+### Artículo 181
 
 1. Los cuerpos de bomberos de Chile conforman una institución perteneciente al sistema de protección civil, cuyo objeto es atender las emergencias causadas por la naturaleza o el ser humano, sin perjuicio de la competencia específica que tengan otros organismos públicos y/o privados.
 2. El Estado deberá dar cobertura financiera para cubrir la totalidad de sus gastos operacionales, capacitación y equipos, como también otorgar cobertura médica a su personal por accidentes o enfermedades contraídas
 por actos de servicio.
 3. Los cuerpos de bomberos de Chile se sujetarán en todas sus actuaciones a los principios de probidad, transparencia y rendición de cuentas.
 
-### Artículo 182
+### Artículo 182
 
 1. El Estado participa en la economía para cumplir sus fines constitucionales, de acuerdo con los principios y objetivos económicos de solidaridad, pluralismo económico, diversificación productiva y economía social y solidaria. En el ejercicio de sus potestades regula, fiscaliza, fomenta y desarrolla actividades económicas, conforme a lo establecido en esta Constitución y la ley.
 2. La Constitución reconoce al Estado iniciativa para desarrollar actividades económicas, mediante las formas diversas de propiedad, gestión y organización que autorice la ley.
@@ -99,18 +99,18 @@ por actos de servicio.
 4. El Estado fomentará la innovación, los mercados locales, los circuitos cortos y la economía circular.
 5. El Estado debe prevenir y sancionar los abusos en los mercados. Las prácticas de colusión entre empresas y abusos de posición dominante, así como las concentraciones empresariales que afecten el funcionamiento eficiente, justo y leal de los mercados, se entenderán como conductas contrarias al interés social. La ley establecerá las sanciones a los responsables.
 
-### Artículo 183
+### Artículo 183
 
 1. Las finanzas públicas se conducirán conforme a los principios de sostenibilidad y responsabilidad fiscal, los que guiarán el actuar del Estado en todas sus instituciones y en todos sus niveles.
 2. El Estado usará sus recursos de forma razonable, óptima, eficaz y eficiente, en beneficio de las personas y en función de los objetivos que la Constitución y las leyes les impongan.
 3. Sin perjuicio de los distintos tipos de responsabilidad a que pueda dar lugar el incumplimiento de las obligaciones en materia financiera, la ley deberá establecer mecanismos para un resarcimiento efectivo del patrimonio público.
 
-### Artículo 184
+### Artículo 184
 
 1. Es deber del Estado en el ámbito de sus competencias financieras, establecer una política permanente de desarrollo sostenible y armónico con la naturaleza.
 2. Con el objeto de contar con recursos para el cuidado y la reparación de los ecosistemas, la ley podrá establecer tributos sobre actividades que afecten al medioambiente. Asimismo, la ley podrá establecer tributos sobre el uso de bienes comunes naturales, bienes nacionales de uso público o bienes fiscales. Cuando dichas actividades estén territorialmente circunscritas, la ley debe distribuir recursos a la entidad territorial que corresponda.
 
-### Artículo 185
+### Artículo 185
 
 1. Todas las personas y entidades deberán contribuir al sostenimiento de los gastos públicos mediante el pago de los impuestos, las tasas y las contribuciones que autorice la ley. El sistema tributario se funda en los principios de igualdad, progresividad, solidaridad y justicia material, el cual, en ningún caso, tendrá alcance confiscatorio. Tendrá dentro de sus objetivos la reducción de las desigualdades y la pobreza.
 2. El ejercicio de la potestad tributaria admite la creación de tributos que respondan a fines distintos de la recaudación, debiendo tener en consideración límites tales como la necesidad, la razonabilidad y la transparencia.
@@ -119,6 +119,6 @@ por actos de servicio.
 5. Anualmente, la autoridad competente publicará, conforme a la ley, los ingresos afectos a impuestos y las cargas tributarias estatales, regionales y comunales, así como los beneficios tributarios, subsidios, subvenciones o bonificaciones de fomento a la actividad empresarial, incluyendo personas naturales y jurídicas. También deberá estimarse anualmente en la Ley de Presupuestos y publicarse el costo de estos beneficios fiscales.
 6. No procederá plebiscito y referéndum en materia tributaria.
 
-### Artículo 186
+### Artículo 186
 
 El Estado fijará una política nacional portuaria, orientada por los principios de eficiencia en el uso del borde costero; responsabilidad ambiental, con especial énfasis en el cuidado de la naturaleza y bienes comunes naturales; participación pública en los recursos que genere la actividad; vinculación con el territorio y las comunidades en las cuales se emplacen los recintos portuarios; reconocimiento de la carrera profesional portuaria como trabajo de alto riesgo, y colaboración entre recintos e infraestructura portuaria para asegurar el oportuno abastecimiento de las comunidades.

--- a/Markdown/06 - Estado Regional y Organización Territorial.md
+++ b/Markdown/06 - Estado Regional y Organización Territorial.md
@@ -1,13 +1,13 @@
 # Capítulo VI: Estado Regional y Organización Territorial
 
-### Artículo 187
+### Artículo 187
 
 1. El Estado se organiza territorialmente en entidades territoriales autónomas y territorios especiales.
 2. Son entidades territoriales autónomas las comunas autónomas, regiones autónomas y autonomías territoriales indígenas. Están dotadas de autonomía política, administrativa y financiera para la realización de sus fines e intereses. Tienen personalidad jurídica de derecho público, patrimonio propio y las potestades y competencias necesarias para gobernarse en atención al interés general de la república, de acuerdo con la Constitución y la ley, teniendo como límites los derechos humanos y de la naturaleza.
 3. La creación, modificación, delimitación y supresión de las entidades territoriales deberá considerar criterios objetivos en función de antecedentes históricos, geográficos, sociales, culturales, ecosistémicos y económicos, garantizando la participación popular, democrática y vinculante de sus habitantes.
 4. En ningún caso el ejercicio de la autonomía podrá atentar en contra del carácter único e indivisible del Estado de Chile ni permitirá la secesión territorial.
 
-### Artículo 188
+### Artículo 188
 
 1. Las entidades territoriales se coordinan y asocian en relaciones de solidaridad, cooperación, reciprocidad y apoyo mutuo, evitando la duplicidad de funciones, conforme a los mecanismos que establezca la ley.
 2. Dos o más entidades territoriales, con o sin continuidad territorial, podrán suscribir convenios y constituir asociaciones territoriales con la finalidad de lograr objetivos comunes, promover la cohesión social, mejorar la prestación de los servicios públicos, incrementar la eficiencia y eficacia en el ejercicio de sus competencias y potenciar el desarrollo social, cultural, económico sostenible y equilibrado.
@@ -15,72 +15,72 @@
 4. La ley establecerá las bases generales para la creación y el funcionamiento de estas asociaciones, en concordancia con la normativa regional respectiva.
 5. Las asociaciones de entidades territoriales, en ningún caso, alterarán la organización territorial del Estado.
 
-### Artículo 189
+### Artículo 189
 
 1. La Constitución garantiza un tratamiento equitativo y un desarrollo armónico y solidario entre las diversas entidades territoriales, tanto urbanas como rurales. Propenderá al interés general e integración efectiva y no podrá establecer diferencias arbitrarias entre ellas.
 2. El Estado asegura a todas las personas la equidad horizontal en el acceso a los bienes y servicios públicos, al empleo y a todas las prestaciones estatales, sin perjuicio del lugar que habiten en el territorio, estableciendo, de ser necesario, acciones afirmativas en favor de los grupos de especial protección.
 
-### Artículo 190
+### Artículo 190
 
 Las entidades territoriales y sus órganos deben actuar coordinadamente en cumplimiento de los principios de plurinacionalidad e interculturalidad; respetar y proteger las diversas formas de concebir y organizar el mundo, de relacionarse con la naturaleza; y garantizar los derechos de autodeterminación y de autonomía de los pueblos y naciones indígenas.
 
-### Artículo 191
+### Artículo 191
 
 Participación en las entidades territoriales en el Estado regional.
 
 1. Las entidades territoriales garantizan el derecho de sus habitantes a participar, individual o colectivamente en las decisiones públicas, comprendiendo en ella la formulación, la ejecución, la evaluación, la fiscalización y el control democrático de la función pública, con arreglo a la Constitución y las leyes.
 2. Los pueblos y naciones indígenas deberán ser consultados y otorgarán el consentimiento libre, previo e informado en aquellas materias o asuntos que les afecten en sus derechos reconocidos en esta Constitución.
 
-### Artículo 192
+### Artículo 192
 
 Las entidades territoriales deberán promover, fomentar y garantizar los mecanismos de participación en las políticas públicas, planes y programas que se implementen en cada nivel territorial, en los casos que esta Constitución, la ley y los estatutos regionales señalen.
 
-### Artículo 193
+### Artículo 193
 
 1. Es deber de las entidades territoriales, en el ámbito de sus competencias, establecer una política permanente de equidad territorial, de desarrollo sostenible y armónico con la naturaleza.
 2. Las entidades territoriales considerarán para su planificación social, política, administrativa, cultural, territorial y económica los principios de suficiencia presupuestaria, inclusión e interculturalidad, criterios de integración socioespacial, enfoques de género, socioecosistémico, de derechos humanos y los demás que establezca esta Constitución.
 
-### Artículo 194
+### Artículo 194
 
 Entre entidades territoriales rige el principio de no tutela. Ninguna entidad territorial podrá ejercer tutela sobre otra, sin perjuicio de la aplicación de los principios de coordinación, de asociatividad, de solidaridad y de los conflictos de competencias que puedan ocasionarse.
 
-### Artículo 195
+### Artículo 195
 
 1. La Administración central podrá transferir a las entidades territoriales las competencias que determine la ley, sin perjuicio de aquellas señaladas en esta Constitución. Esta transferencia deberá considerar siempre el personal y los recursos financieros oportunos y suficientes para su adecuada ejecución. Corresponderá a la ley establecer el procedimiento, así como sus mecanismos de evaluación y control.
 2. El Estado, además, debe generar políticas públicas diferenciadas. La ley establecerá los criterios y requisitos para la aplicación de estas diferencias, así como los mecanismos de solidaridad y equidad que compensen las desigualdades entre los distintos niveles territoriales.
 
-### Artículo 196
+### Artículo 196
 
 1. Las competencias deberán radicarse priorizando la entidad local sobre la regional y esta última sobre la nacional, sin perjuicio de aquellas competencias que la propia Constitución o las leyes reserven a cada una de las entidades territoriales.
 2. Cuando así lo exija el interés general, el órgano de la Administración central o regional podrá subrogar de manera transitoria a la entidad regional o local en el ejercicio de las competencias que no puedan ser asumidas por estas.
 
-### Artículo 197
+### Artículo 197
 
 1. El Estado, a través de la Administración central, los gobiernos regionales y locales, tienen el deber de ordenar y planificar el territorio. Para esto, utilizarán unidades de ordenación que consideren las cuencas hidrográficas.
 2. Este deber tendrá como fin asegurar una adecuada localización de los asentamientos y las actividades productivas, que permitan un manejo responsable de los ecosistemas y de las actividades humanas, con criterios de equidad y justicia territorial para el bienestar intergeneracional.
 3. Los planes de ordenamiento y planificación ecológica del territorio priorizarán la protección de las partes altas de las cuencas, glaciares, zonas de recarga natural de acuíferos y ecosistemas. Estos podrán definir áreas de protección ambiental o cultural y crear zonas de amortiguamiento para estas. Asimismo, contemplarán los impactos que los usos de suelos causen en la disponibilidad y calidad de las aguas.
 4. La ordenación y planificación de los territorios será vinculante en las materias que la ley determine. Serán ejecutadas de manera coordinada e integrada, enfocadas en el interés general y con procesos de participación popular en sus diferentes etapas.
 
-### Artículo 198
+### Artículo 198
 
 El Estado es garante de la conectividad del país en coordinación con los gobiernos regionales. Se fomentará la conectividad regional con especial atención a territorios aislados, rurales y de difícil acceso.
 
-### Artículo 199
+### Artículo 199
 
 Las comunas y regiones autónomas ubicadas en zonas fronterizas podrán vincularse con las entidades territoriales limítrofes del país vecino, a través de sus respectivas autoridades, para establecer programas de cooperación e integración, dirigidos a fomentar el desarrollo comunitario, la prestación de servicios públicos y la conservación del medioambiente, según los términos que establezca esta Constitución y la ley.
 
-### Artículo 200
+### Artículo 200
 
 La elección de representantes por votación popular de las entidades territoriales se efectuará asegurando la representatividad territorial, la pertenencia territorial y el avecindamiento respectivo.
 
 ## Comuna autónoma
 
-### Artículo 201
+### Artículo 201
 
 1. La comuna autónoma es la entidad política y territorial base del Estado regional, dotada de personalidad jurídica de derecho público y patrimonio propio, que goza de autonomía para el cumplimiento de sus fines y el ejercicio de sus competencias, con arreglo a lo dispuesto en la Constitución y la ley.
 2. La ley clasificará las comunas en distintos tipos, las que deberán ser consideradas por los órganos del Estado para el establecimiento de regímenes administrativos y económico-fiscales diferenciados, la implementación de políticas, planes y programas atendiendo a las diversas realidades locales, y en especial, para el traspaso de competencias y recursos. El establecimiento de los tipos comunales deberá considerar, a lo menos, criterios demográficos, económicos, culturales, geográficos, socioambientales, urbanos y rurales.
 
-### Artículo 202
+### Artículo 202
 
 La comuna autónoma cuenta con las potestades y competencias de autogobierno para satisfacer las necesidades de la comunidad local. Son competencias esenciales de la comuna autónoma:
 
@@ -106,25 +106,25 @@ La comuna autónoma cuenta con las potestades y competencias de autogobierno pa
 - s) La promoción de la seguridad ciudadana.
 - t) Las demás competencias que determinen la Constitución y la ley. Las leyes deberán reconocer las diferencias existentes entre los distintos tipos de comunas y municipalidades, velando por la equidad, inclusión y cohesión territorial.
 
-### Artículo 203
+### Artículo 203
 
 1. A fin de garantizar el respeto, la protección y la realización progresiva de los derechos económicos y sociales en igualdad de condiciones, las comunas autónomas podrán encomendar temporalmente una o más competencias a la región autónoma respectiva o la Administración central, conforme a lo establecido en la ley.
 2. A petición de la alcaldesa o del alcalde, con acuerdo del concejo municipal, la región autónoma o la Administración central, cuando así lo exija el interés general, podrán subrogar de forma transitoria a la comuna autónoma en el ejercicio de las competencias que no puedan ser asumidas por esta.
 
-### Artículo 204
+### Artículo 204
 
 La alcaldesa o el alcalde, con aprobación del concejo municipal, podrá establecer delegaciones para el ejercicio de las facultades de la comuna autónoma en los casos y las formas que determine la ley.
 
-### Artículo 205
+### Artículo 205
 
 El gobierno de la comuna autónoma reside en la municipalidad, la que estará constituida por la alcaldesa o el alcalde y el concejo municipal, con la participación de la comunidad que habita en su territorio.
 
-### Artículo 206
+### Artículo 206
 
 1. La alcaldesa o el alcalde es la máxima autoridad ejecutiva del gobierno comunal, integra y preside el concejo municipal y representa judicial y extrajudicialmente a la comuna.
 2. Ejercerá sus funciones por el término de cuatros años y se podrá reelegir consecutivamente solo una vez para el período siguiente. Para estos efectos se entenderá que ha ejercido su cargo durante un período cuando haya cumplido más de la mitad de su mandato.
 
-### Artículo 207
+### Artículo 207
 
 1. El concejo municipal es el órgano colegiado de representación popular y vecinal, dotado de funciones normativas, resolutivas y fiscalizadoras. Estará integrado por el número de personas en proporción a la población de la comuna, conforme a la Constitución y la ley. La ley establecerá un régimen de inhabilidades e incompatibilidades.
 2. Quienes integren el concejo municipal ejercerán sus funciones por el término de cuatro años y se podrán reelegir consecutivamente solo una vez para el período siguiente. Para estos efectos se entenderá que han ejercido su cargo durante un período cuando hayan cumplido más de la mitad de su mandato.
@@ -132,66 +132,66 @@ El gobierno de la comuna autónoma reside en la municipalidad, la que estará 
 4. Será necesario el acuerdo del concejo para la aprobación del plan comunal de desarrollo, del presupuesto municipal y de los proyectos de inversión respectivos, y otros que determine la ley.
 5. Será igualmente necesario el acuerdo del concejo para la aprobación del plan regulador comunal.
 
-### Artículo 208
+### Artículo 208
 
 Cada comuna tendrá un estatuto comunal elaborado y aprobado por el concejo municipal. Sin perjuicio de los mínimos generales dispuestos por la ley para todas las comunas, el estatuto comunal establece la organización administrativa y el funcionamiento de los órganos comunales, los mecanismos de democracia vecinal y las normas de elaboración de ordenanzas comunales.
 
-### Artículo 209
+### Artículo 209
 
 1. La asamblea social comunal tiene la finalidad de promover la participación popular y ciudadana en los asuntos públicos. Será de carácter consultivo, incidente y representativo de las organizaciones de la comuna.
 2. Su integración, organización, funcionamiento y atribuciones serán establecidos por ley y complementados por el estatuto regional.
 
-### Artículo 210
+### Artículo 210
 
 1. Las comunas establecerán territorios denominados unidades vecinales. Dentro de la unidad vecinal se constituirá una junta vecinal, representativa de las personas que residen en ella, la que contará con personalidad jurídica y no tendrá fines de lucro. Su objeto será hacer efectiva la participación popular en la gestión comunal y en el desarrollo de la comunidad. En comunas con población rural, podrá constituirse además una unión comunal de juntas vecinales de carácter rural.
 2. La ley dispondrá la forma de determinar el territorio de las unidades vecinales, el procedimiento de constitución de las juntas vecinales y uniones comunales y sus atribuciones.
 
-### Artículo 211
+### Artículo 211
 
 1. El consejo de alcaldesas y alcaldes es un órgano de carácter consultivo y representativo de todas las comunas de la región autónoma. Será coordinado por quien determinen sus integrantes por mayoría en ejercicio.
 2. Deberá sesionar y abordar las problemáticas de la región autónoma, promover una coordinación efectiva entre los distintos órganos con presencia regional y fomentar una cooperación eficaz entre los gobiernos comunales.
 
-### Artículo 212
+### Artículo 212
 
 1. La Administración central del Estado garantiza a la municipalidad el financiamiento y los recursos suficientes para el justo y equitativo desarrollo de cada comuna.
 2. Asimismo, debe observar como principio básico para el gobierno comunal la búsqueda de un desarrollo territorial armónico y equitativo, propendiendo a que todas las personas tengan acceso a igual nivel y calidad de servicios públicos municipales, sin distinción del lugar que habiten.
 
-### Artículo 213
+### Artículo 213
 
 1. Las comunas autónomas podrán asociarse entre sí, de manera permanente o temporal. Contarán con personalidad jurídica de derecho privado y se regirán por la normativa propia de dicho sector.
 2. Sin perjuicio de lo dispuesto en el inciso precedente, las asociaciones quedarán sujetas a la fiscalización de la Contraloría General de la República y deberán cumplir con la normativa de probidad administrativa y de transparencia en el ejercicio de la función que desarrollan.
 
-### Artículo 214
+### Artículo 214
 
 Las comunas autónomas, a fin de cumplir con sus funciones y ejercer sus atribuciones, podrán crear empresas, o participar en ellas, ya sea individualmente o asociadas con otras entidades públicas o privadas, previa autorización por ley general o especial. Las empresas públicas municipales tendrán personalidad jurídica y patrimonio propio y se regirán en conformidad con lo dispuesto en la Constitución y la ley.
 
-### Artículo 215
+### Artículo 215
 
 1. La creación, división o fusión de comunas autónomas o la modificación de sus límites o denominación se determinará por ley, respetando en todo caso criterios objetivos, según lo dispuesto en la Constitución.
 2. Una ley regulará la administración transitoria de las comunas que se creen; el procedimiento de instalación de las nuevas municipalidades, de traspaso del personal municipal y de los servicios, y los resguardos necesarios para cautelar el uso y la disposición de los bienes que se encuentren situados en los territorios de las nuevas comunas.
 
-### Artículo 216
+### Artículo 216
 
 1. Las municipalidades tienen el deber de promover y garantizar la participación ciudadana de la comunidad local en la gestión, en la construcción de políticas de desarrollo local y en la planificación del territorio, así como en los casos que esta Constitución, la ley y los estatutos regionales o comunales señalen.
 2. Estas proveerán los mecanismos, los espacios, los recursos, la alfabetización digital, la formación y la educación cívica y todo aquello que sea necesario para concretar dicha participación, que será consultiva, incidente y, en su caso, vinculante de acuerdo con la legislación respectiva.
 
-### Artículo 217
+### Artículo 217
 
 Las municipalidades podrán establecer sus plantas de personal y los órganos o las unidades de su estructura interna, conforme a la ley, cautelando la carrera funcionaria y su debido financiamiento.
 
 ## Provincia
 
-### Artículo 218
+### Artículo 218
 
 La provincia es una división territorial establecida con fines administrativos y está compuesta por una agrupación de comunas autónomas.
 
 ## Región autónoma
 
-### Artículo 219
+### Artículo 219
 
 La región autónoma es la entidad política y territorial dotada de personalidad jurídica de derecho público y patrimonio propio que goza de autonomía para el desarrollo de los intereses regionales, la gestión de sus recursos económicos y el ejercicio de las atribuciones legislativas, reglamentarias, ejecutivas y fiscalizadoras a través de sus órganos en el ámbito de sus competencias, con arreglo a lo dispuesto en la Constitución y la ley.
 
-### Artículo 220
+### Artículo 220
 
 Son competencias de la región autónoma:
 
@@ -218,16 +218,16 @@ Son competencias de la región autónoma:
 - t) Participar en acciones de cooperación internacional, dentro de los marcos establecidos por los tratados y los convenios vigentes.
 - u) Las demás competencias que determinen la Constitución y ley.
 
-### Artículo 221
+### Artículo 221
 
 1. Las competencias no expresamente conferidas a la región autónoma corresponden a la Administración central, sin perjuicio de las transferencias de competencias que regulan la Constitución y la ley.
 2. Las competencias de la región autónoma podrán ejercerse de manera concurrente y coordinada con otros órganos del Estado.
 
-### Artículo 222
+### Artículo 222
 
 La organización institucional de las regiones autónomas se compone del gobierno regional y de la asamblea regional.
 
-### Artículo 223
+### Artículo 223
 
 1. El gobierno regional es el órgano ejecutivo de la región autónoma.
 2. Una gobernadora o un gobernador regional dirige el gobierno regional, ejerce la función de gobierno y administración y representa judicial y extrajudicialmente a la región.
@@ -235,7 +235,7 @@ La organización institucional de las regiones autónomas se compone del gobie
 4. En la elección respectiva, resultará electo quien obtenga la mayoría de los votos válidamente emitidos. Si ninguna persona logra al menos el cuarenta por ciento de los votos, se producirá una segunda votación entre quienes hayan obtenido las dos más altas mayorías. Resultará elegido quien obtenga la mayoría de los votos válidamente emitidos.
 5. Quien dirija el gobierno regional ejercerá sus funciones por el término de cuatro años, pudiendo reelegirse consecutivamente solo una vez para el período siguiente. En este caso, se considerará que se ha ejercido el cargo durante un período cuando se haya cumplido más de la mitad del mandato.
 
-### Artículo 224
+### Artículo 224
 
 Son atribuciones esenciales de los gobiernos regionales las siguientes:
 
@@ -258,13 +258,13 @@ asiento en la región autónoma, que incluyan, a lo menos, su preparación, p
 - o) Celebrar y ejecutar acciones de cooperación internacional, dentro de los marcos establecidos por los tratados y convenios que el país celebre al efecto y conforme a los procedimientos regulados en la ley.
 - p) Las demás atribuciones que señalen la Constitución, la ley y el estatuto regional.
 
-### Artículo 225
+### Artículo 225
 
 1. La asamblea regional es el órgano colegiado de representación regional que está dotado de potestades normativas, resolutivas y fiscalizadoras.
 2. Una ley determinará los requisitos generales para acceder al cargo de asambleísta regional y su número en proporción a la población regional.
 3. Quienes desempeñen el cargo de asambleísta regional ejercerán sus funciones por el término de cuatro años, pudiendo reelegirse consecutivamente solo una vez para el período inmediatamente siguiente. En este caso, se considerará que han ejercido el cargo durante un período cuando hayan cumplido más de la mitad de su mandato.
 
-### Artículo 226
+### Artículo 226
 
 Son atribuciones de la asamblea regional:
 
@@ -285,22 +285,22 @@ Son atribuciones de la asamblea regional:
 - ñ) Aprobar, a propuesta de la gobernadora o del gobernador regional y previa ratificación de la Cámara de las Regiones, la creación de empresas públicas regionales o la participación en empresas regionales.
 - o) Las demás atribuciones que determinen la Constitución y la ley.
 
-### Artículo 227
+### Artículo 227
 
 1. La organización administrativa y funcionamiento interno de cada región autónoma serán establecidas en un estatuto.
 2. El estatuto regional debe respetar los derechos fundamentales y los principios del Estado social y democrático de derecho reconocidos en la Constitución.
 
-### Artículo 228
+### Artículo 228
 
 1. El proyecto de estatuto regional será elaborado y propuesto por quien dirija el gobierno regional a la asamblea regional respectiva, para su deliberación y acuerdo, el cual será aprobado por la mayoría en ejercicio.
 2. El proceso de elaboración y reforma de este deberá garantizar la participación popular, democrática y vinculante de los habitantes de la región autónoma respectiva.
 
-### Artículo 229
+### Artículo 229
 
 1. El consejo social regional es el encargado de promover la participación popular en los asuntos públicos regionales de carácter participativo y consultivo. Su integración y competencias serán determinadas por ley.
 2. Quien dirija el gobierno regional y las jefaturas de los servicios públicos regionales deberán rendir cuenta ante el consejo social regional, a lo menos una vez al año, de la ejecución presupuestaria y del desarrollo de proyectos en los términos prescritos por el estatuto regional.
 
-### Artículo 230
+### Artículo 230
 
 1. El Consejo de Gobernaciones, presidido por el Presidente de la República y conformado por las gobernadoras y los gobernadores de cada región, coordinará las relaciones entre la Administración central y las entidades territoriales, velando por el bienestar social y económico equilibrado de la república en su conjunto.
 2. Son facultades del Consejo de Gobernaciones:
@@ -312,16 +312,16 @@ Son atribuciones de la asamblea regional:
     - f) Acordar la creación de comisiones o grupos de trabajo para el estudio de asuntos de interés común.
     - g) Las demás que establezcan la Constitución y la ley.
 
-### Artículo 231
+### Artículo 231
 
 1. La región autónoma podrá establecer sus plantas de personal y los órganos o las unidades de su estructura interna conforme a la ley cautelando la carrera funcionaria y su debido financiamiento.
 2. Estas facultades serán ejecutadas por quien presida la gobernación, previo acuerdo de la asamblea regional.
 
-### Artículo 232
+### Artículo 232
 
 La ley determinará los servicios públicos, las instituciones o empresas del Estado que, en virtud de sus fines fiscalizadores o por razones de eficiencia y de interés general, mantendrán una organización centralizada o desconcentrada en todo el territorio de la república.
 
-### Artículo 233
+### Artículo 233
 
 1. Las regiones autónomas cuentan con las competencias para coordinarse con quienes representen a los ministerios y servicios públicos con presencia en la región autónoma.
 2. El gobierno regional podrá solicitar a la Administración central la transferencia de competencias de ministerios y servicios públicos. A su vez, las municipalidades podrán solicitar al gobierno regional la transferencia de competencias.
@@ -331,74 +331,74 @@ La ley determinará los servicios públicos, las instituciones o empresas del 
 
 ## Autonomía territorial indígena
 
-### Artículo 234
+### Artículo 234
 
 1. La autonomía territorial indígena es la entidad territorial dotada de personalidad jurídica de derecho público y patrimonio propio, donde los pueblos y naciones indígenas ejercen derechos de autonomía en coordinación con las demás entidades territoriales. Es deber del Estado reconocer, promover y garantizar las autonomías territoriales indígenas para el cumplimiento de sus fines.
 2. La ley, mediante un proceso de participación y consulta previa, creará un procedimiento oportuno, eficiente y transparente para la constitución de las autonomías territoriales indígenas. Dicho procedimiento deberá iniciarse a requerimiento de los pueblos y naciones indígenas interesados, a través de sus autoridades representativas.
 
-### Artículo 235
+### Artículo 235
 
 La ley deberá establecer las competencias exclusivas de las autonomías territoriales indígenas y las compartidas con las demás entidades territoriales. Las autonomías territoriales indígenas deberán tener las competencias y el financiamiento necesarios para el adecuado ejercicio del derecho de libre determinación de los pueblos y naciones indígenas.
 
 ## Territorios especiales
 
-### Artículo 236
+### Artículo 236
 
 1. Son territorios especiales Rapa Nui y el archipiélago Juan Fernández, los que se rigen por sus respectivos estatutos.
 2. En virtud de las particularidades geográficas, climáticas, ambientales, económicas, sociales y culturales de una determinada entidad territorial o parte de esta, la ley podrá crear territorios especiales.
 3. En los territorios especiales, la ley podrá establecer regímenes económicos y administrativos diferenciados, así como su duración, teniendo en consideración las características propias de estas entidades.
 
-### Artículo 237
+### Artículo 237
 
 1. La ley creará y regulará la administración de un Fondo para Territorios Especiales, cuyos recursos serán destinados exclusivamente a los fines para los cuales fueron creados.
 2. Asimismo, la Administración central y las entidades territoriales autónomas deberán destinar recursos propios al financiamiento de los territorios especiales respectivos.
 
-### Artículo 238
+### Artículo 238
 
 En el territorio especial de Rapa Nui, el Estado garantiza el derecho a la libre determinación y autonomía del pueblo nación polinésico Rapanui, asegurando los medios para financiar y promover su desarrollo, protección y bienestar en virtud del Acuerdo de Voluntades firmado en 1888, por el cual se incorpora a Chile. Se reconoce al pueblo Rapanui la titularidad colectiva de los derechos sobre el territorio con excepción de los derechos sobre tierras individuales de sus miembros. Un estatuto de autonomía regulará el territorio Rapa Nui.
 
-### Artículo 239
+### Artículo 239
 
 El archipiélago Juan Fernández es un territorio especial conformado por las islas Robinson Crusoe, Alejandro Selkirk, Santa Clara, San Félix y San Ambrosio, y el territorio marítimo adyacente a ellas. El gobierno y la administración de este territorio se regirán por los estatutos especiales que establezca la ley.
 
-### Artículo 240
+### Artículo 240
 
 El territorio chileno antártico, incluyendo sus espacios marítimos, es un territorio especial y zona fronteriza en el cual Chile ejerce respectivamente soberanía y derechos soberanos, con pleno respeto a los tratados ratificados y vigentes. El Estado deberá conservar, proteger y cuidar la Antártica, mediante una política fundada en el conocimiento y orientada a la investigación científica, la colaboración internacional y la paz.
 
 ## Ruralidad
 
-### Artículo 241
+### Artículo 241
 
 1. El Estado promueve el desarrollo integral de los territorios rurales y reconoce la ruralidad como una expresión territorial donde las formas de vida y producción se desarrollan en torno a la relación directa de las personas y comunidades con la tierra, el agua y el mar.
 2. Asimismo, facilitará la participación de las comunidades rurales a nivel local y regional en el diseño y la implementación de programas y políticas públicas que les afectan o conciernen.
 
-### Artículo 242
+### Artículo 242
 
 El Estado adoptará las medidas necesarias para prevenir la violencia y superar las desigualdades que enfrentan mujeres y niñas rurales, promoviendo la implementación de políticas públicas que garanticen el goce igualitario de los derechos que la Constitución consagra.
 
-### Artículo 243
+### Artículo 243
 
 El Estado fomenta los mercados locales, las ferias libres y los circuitos cortos de comercialización e intercambio de bienes y productos relacionados a la ruralidad.
 
 ## Autonomía fiscal
 
-### Artículo 244
+### Artículo 244
 
 1. La actividad financiera de las entidades territoriales se realizará coordinadamente entre ellas, el Estado y las autoridades competentes, las cuales deberán cooperar y colaborar entre sí y evitar la duplicidad e interferencia de funciones, velando en todo momento por la satisfacción del interés general.
 2. Lo anterior se aplicará también respecto de todas las competencias o potestades que se atribuyan a las entidades territoriales.
 
-### Artículo 245
+### Artículo 245
 
 1. Las entidades territoriales autónomas cuentan con autonomía financiera en sus ingresos y gastos para el cumplimiento de sus competencias, la cual deberá ajustarse a los principios de suficiencia, coordinación, equilibrio presupuestario, solidaridad y compensación interterritorial, sostenibilidad, responsabilidad y eficiencia económica.
 2. La Ley de Presupuestos deberá propender a que, progresivamente, una parte significativa del gasto público sea ejecutado a través de los gobiernos subnacionales, en función de las responsabilidades propias que debe asumir cada nivel de gobierno.
 3. El deber y la facultad de velar por la estabilidad macroeconómica y fiscal serán centralizados.
 
-### Artículo 246
+### Artículo 246
 
 1. La autonomía financiera de las entidades territoriales implica la facultad de ordenar y gestionar sus finanzas públicas en el marco de la Constitución y las leyes, en beneficio de sus habitantes, bajo los criterios de responsabilidad y sostenibilidad financiera.
 2. La suficiencia financiera se determinará bajo criterios objetivos tales como correspondencia entre competencias y recursos necesarios para su cumplimiento, equilibrio presupuestario, coordinación, no discriminación arbitraria entre entidades territoriales, igualdad en las prestaciones sociales, desarrollo armónico de los territorios, unidad, objetividad, razonabilidad, oportunidad y transparencia.
 
-### Artículo 247
+### Artículo 247
 
 Las entidades territoriales tendrán las siguientes fuentes de ingresos:
 
@@ -412,13 +412,13 @@ Las entidades territoriales tendrán las siguientes fuentes de ingresos:
 - h) Las donaciones, las herencias y los legados que reciban conforme a la ley.
 - i) Otras que determinen la Constitución y la ley.
 
-### Artículo 248
+### Artículo 248
 
 1. Los ingresos fiscales generados por impuestos son distribuidos entre la Administración central y las entidades territoriales en la forma establecida en la Ley de Presupuestos.
 2. La ley definirá el órgano encargado de recopilar y sistematizar la información necesaria para proponer al Poder Legislativo las fórmulas de distribución de los ingresos fiscales, de compensación fiscal entre entidades territoriales y de los recursos a integrar en los diversos fondos. Para estos efectos, se deberá considerar la participación y representación de las entidades territoriales.
 3. Durante el trámite legislativo presupuestario, el órgano competente sugerirá una fórmula de distribución de ingresos fiscales, la cual considerará los criterios de distribución establecidos por la ley.
 
-### Artículo 249
+### Artículo 249
 
 1. La Administración y las entidades territoriales deben contribuir a la corrección de las desigualdades que existan entre ellas.
 2. La ley establecerá fondos de compensación para las entidades territoriales
@@ -427,7 +427,7 @@ con una menor capacidad fiscal. El órgano competente, sobre la base de criteri
 4. En virtud de la solidaridad interterritorial, la Administración central deberá realizar transferencias directas incondicionales a las entidades territoriales que cuenten con ingresos fiscales inferiores a la mitad del promedio ponderado de estas.
 5. Las regiones y comunas autónomas que cuenten con ingresos por sobre el promedio ponderado de ingresos fiscales transferirán recursos a aquellas equivalentes con ingresos bajo el promedio. El órgano competente sugerirá una fórmula al legislador para realizar tales transferencias.
 
-### Artículo 250
+### Artículo 250
 
 Los gobiernos regionales y locales podrán emitir deuda en conformidad con lo que disponga la ley, general o especial, la que establecerá al menos las siguientes regulaciones:
 

--- a/Markdown/07 - Poder Legislativo.md
+++ b/Markdown/07 - Poder Legislativo.md
@@ -1,19 +1,19 @@
 # Capítulo VII: Poder Legislativo
 
-### Artículo 251
+### Artículo 251
 
 El Poder Legislativo se compone del Congreso de Diputadas y Diputados y de
 la Cámara de las Regiones.
 
 ## Congreso de Diputadas y Diputados
 
-### Artículo 252
+### Artículo 252
 
 1. El Congreso de Diputadas y Diputados es un órgano deliberativo, paritario y plurinacional que representa al pueblo. Concurre a la formación de las leyes y ejerce las demás facultades encomendadas por la Constitución.
 2. El Congreso está integrado por un número no inferior a ciento cincuenta y cinco integrantes electos en votación directa por distritos electorales. Una ley de acuerdo regional determinará el número de integrantes, los distritos electorales y la forma de su elección, atendiendo al criterio de proporcionalidad.
 3. Los escaños reservados en el Congreso de Diputadas y Diputados para los pueblos y naciones indígenas serán elegidos en un distrito único nacional. Su número se define en forma proporcional a la población indígena en relación con la población total del país. Se deben adicionar al número total de integrantes del Congreso. La ley regulará los requisitos, los procedimientos y la distribución de los escaños reservados.
 
-### Artículo 253
+### Artículo 253
 
 Son atribuciones exclusivas del Congreso de Diputadas y Diputados:
 
@@ -43,7 +43,7 @@ Son atribuciones exclusivas del Congreso de Diputadas y Diputados:
 
 ## Cámara de las Regiones
 
-### Artículo 254
+### Artículo 254
 
 1. La Cámara de las Regiones es un órgano deliberativo, paritario y plurinacional de representación regional encargado de concurrir a la formación de las leyes de acuerdo regional y de ejercer las demás facultades encomendadas por esta Constitución.
 2. Sus integrantes se denominan representantes regionales y se eligen en votación popular, conjuntamente con las autoridades comunales y regionales, tres años después de la elección presidencial y del Congreso.
@@ -52,7 +52,7 @@ Son atribuciones exclusivas del Congreso de Diputadas y Diputados:
 5. También podrán ser especialmente convocadas y convocados al efecto.
 La Cámara de las Regiones no podrá fiscalizar los actos del Gobierno ni la institucionalidad que de él dependan.
 
-### Artículo 255
+### Artículo 255
 
 1. Es atribución exclusiva de la Cámara de las Regiones conocer de las acusaciones que entable el Congreso de Diputadas y Diputados.
 2. La Cámara de las Regiones resolverá como jurado y se limitará a declarar si la persona acusada es o no culpable.
@@ -62,17 +62,17 @@ La Cámara de las Regiones no podrá fiscalizar los actos del Gobierno ni la ins
 
 ## Disposiciones comunes al Poder Legislativo
 
-### Artículo 256
+### Artículo 256
 
 1. El Congreso de Diputadas y Diputados y la Cámara de las Regiones no podrán entrar en sesión ni adoptar acuerdos sin la concurrencia de la tercera parte de sus miembros en ejercicio. Toman sus decisiones por la mayoría de sus integrantes presentes, salvo que esta Constitución disponga un quorum diferente.
 2. La ley establecerá sus reglas de organización, funcionamiento y tramitación, la que podrá ser complementada con los reglamentos de funcionamiento que estos órganos dicten.
 
-### Artículo 257
+### Artículo 257
 
 1. Para que una persona sea elegida diputada, diputado o representante regional debe ser ciudadana con derecho a sufragio, haber cumplido dieciocho años de edad al día de la elección y tener residencia en el territorio correspondiente durante un plazo no inferior a dos años en el caso de las diputadas o los diputados y de cuatro años en el caso de representantes regionales, contados hacia atrás desde el día de la elección.
 2. Se entenderá que tienen su residencia en el territorio correspondiente mientras ejerzan su cargo.
 
-### Artículo 258
+### Artículo 258
 
 1. No pueden postular al Congreso de Diputadas y Diputados ni a la Cámara de
 las Regiones:
@@ -92,19 +92,19 @@ las Regiones:
     - n) Las y los militares en servicio activo.
 2. Las inhabilidades establecidas en este artículo serán aplicables a quienes hayan tenido las calidades o cargos antes mencionados dentro del año inmediatamente anterior a la elección, excepto respecto de las personas mencionadas en la letra m), las que no deberán reunir esas condiciones al momento de inscribir su candidatura, y de las indicadas en las letras k), l) y n), respecto de las cuales el plazo de la inhabilidad será de los dos años inmediatamente anteriores a la elección.
 
-### Artículo 259
+### Artículo 259
 
 1. Los cargos de diputada o diputado y de representante regional son incompatibles entre sí, con otros cargos de representación y con todo empleo, función, comisión o cargo de carácter público o privado.
 2. Por el solo hecho de su proclamación por el Tribunal Calificador de Elecciones, cesarán en el otro cargo, empleo, función o comisión incompatible que desempeñen.
 
-### Artículo 260
+### Artículo 260
 
 1. Diputadas, diputados y representantes regionales son inviolables por las opiniones que manifiesten y los votos que emitan en el desempeño de sus cargos.
 2. Desde el día de su elección o investidura, no se les puede acusar o privar de libertad, salvo en caso de delito flagrante, si la corte de apelaciones de la jurisdicción respectiva, en pleno, no declara previamente haber lugar a la formación de causa. En contra de las resoluciones que al respecto dicten estas cortes podrá apelarse ante la Corte Suprema.
 3. En caso de que se les detenga por delito flagrante, serán puestos inmediatamente a disposición de la corte de apelaciones respectiva, con la información sumaria correspondiente. La Corte procederá conforme a lo dispuesto en el inciso anterior.
 4. Desde el momento en que se declare, por resolución firme, haber lugar a formación de causa, se les suspenderá de su cargo y se sujetarán al juez competente.
 
-### Artículo 261
+### Artículo 261
 
 1. Cesará en el cargo la diputada, el diputado o representante regional:
     - a) Que se ausente del país por más de treinta días sin permiso de la corporación respectiva o, en receso de esta, de su Mesa Directiva.
@@ -115,7 +115,7 @@ las Regiones:
 2. Diputadas, diputados y representantes regionales podrán renunciar a sus cargos cuando les afecte una enfermedad grave, debidamente acreditada, que les impida desempeñarlos, y así lo califique el Tribunal Calificador de Elecciones.
 3. En caso de vacancia de una diputada o un diputado o de una o un representante regional, la ley determinará su forma de reemplazo. Su reemplazante debe reunir los requisitos establecidos por esta Constitución para ser elegido en el cargo respectivo y le alcanzarán las mismas inhabilidades e incompatibilidades. Se asegurará a todo evento la composición paritaria del órgano.
 
-### Artículo 262
+### Artículo 262
 
 Diputadas, diputados y representantes regionales se renuevan en su totalidad cada cuatro años y pueden ser reelegidos sucesivamente en el cargo hasta por un período. Para estos efectos se entenderá que han ejercido su cargo durante un período cuando han cumplido más de la mitad de su mandato.
 
@@ -135,7 +135,7 @@ El Congreso de Diputadas y Diputados y la Cámara de las Regiones se reunirán e
 
 ## La ley
 
-### Artículo 264
+### Artículo 264
 
 Solo en virtud de una ley se puede:
 
@@ -157,7 +157,7 @@ Solo en virtud de una ley se puede:
 - o) Regular aquellas materias que la Constitución señale como leyes de concurrencia presidencial necesaria.
 - p) Regular las demás materias que la Constitución exija que sean establecidas por una ley.
 
-### Artículo 265
+### Artículo 265
 
 1. La Presidenta o el Presidente de la República podrá solicitar autorización al Congreso de Diputadas y Diputados para dictar decretos con fuerza de ley durante un plazo no superior a un año.
 2. Esta delegación no podrá extenderse a derechos fundamentales, nacionalidad, ciudadanía, elecciones y plebiscitos, ni a la organización, atribuciones y régimen de los funcionarios del Sistema Nacional de Justicia, del Congreso de Diputadas y Diputados, de la Cámara de las Regiones, de la Corte Constitucional o de la Contraloría General de la República.
@@ -167,7 +167,7 @@ Solo en virtud de una ley se puede:
 6. Los decretos con fuerza de ley estarán sometidos, en cuanto a su publicación, vigencia y efectos, a las mismas normas que rigen para la ley.
 7. La ley delegatoria de potestades que correspondan a leyes de acuerdo regional es ley de acuerdo regional.
 
-### Artículo 266
+### Artículo 266
 
 Son leyes de concurrencia presidencial necesaria:
 
@@ -178,7 +178,7 @@ Son leyes de concurrencia presidencial necesaria:
 - e) Las que contraten o autoricen a contratar empréstitos o celebrar cualquier otra clase de operaciones que puedan comprometer la responsabilidad patrimonial del Estado, de los órganos autónomos y condonar, reducir o modificar obligaciones, intereses u otras cargas financieras de cualquier naturaleza establecidas en favor del fisco o de los organismos o entidades referidos sin perjuicio de lo dispuesto en la letra c) del artículo 264.
 - f) Regular las capacidades de la defensa nacional, permitir la entrada de tropas extranjeras al territorio de la república y autorizar la salida de tropas nacionales fuera de él.
 
-### Artículo 267
+### Artículo 267
 
 1. Las leyes de concurrencia presidencial necesaria pueden tener su origen en un mensaje o en una moción.
 2. La moción deberá ser patrocinada por no menos de un cuarto y no más de un tercio de las diputadas y los diputados o, en su caso, de los representantes regionales en ejercicio, y deberá declarar que se trata de un proyecto de ley de concurrencia necesaria de la Presidencia.
@@ -186,7 +186,7 @@ Son leyes de concurrencia presidencial necesaria:
 4. Estas leyes solo podrán ser aprobadas si la Presidenta o el Presidente de la República entrega su patrocinio durante la tramitación del proyecto. Podrá patrocinarlo en cualquier momento hasta transcurridos quince días desde que haya sido despachado para su votación en general por la comisión respectiva, y en todo caso, antes de esta. Transcurrido ese plazo sin el patrocinio correspondiente, el proyecto se entenderá desechado y no se podrá insistir en su tramitación.
 5. Quien ejerza la Presidencia de la República siempre podrá retirar su patrocinio. En dicho caso, la tramitación del proyecto no podrá continuar.
 
-### Artículo 268
+### Artículo 268
 
 1. Solo son leyes de acuerdo regional:
     - a) Las que reformen la Constitución.
@@ -218,35 +218,35 @@ Corte Constitucional por acuerdo de mayoría.
 
 ## Procedimiento legislativo
 
-### Artículo 269
+### Artículo 269
 
 1. Las leyes pueden iniciarse por mensaje de la Presidenta o del Presidente de la República o por moción de no menos del diez por ciento ni más del quince por ciento de diputadas y diputados o representantes regionales. Adicionalmente, podrán tener su origen en iniciativa popular o iniciativa indígena de ley.
 2. Una o más asambleas regionales podrán presentar iniciativas a la Cámara de las Regiones en materias de interés regional. Si esta las patrocina, serán ingresadas como moción ordinaria en el Congreso.
 3. Todos los proyectos de ley, cualquiera sea la forma de su iniciativa, comenzarán su tramitación en el Congreso de Diputadas y Diputados.
 4. Todo proyecto puede ser objeto de adiciones o correcciones en los trámites que corresponda, tanto en el Congreso de Diputadas y Diputados como en la Cámara de las Regiones, si esta interviene conforme con lo establecido en esta Constitución. En ningún caso se admitirán las que no tengan relación directa con las ideas matrices o fundamentales del proyecto.
 
-### Artículo 270
+### Artículo 270
 
 1. Las leyes deberán ser aprobadas, modificadas o derogadas por la mayoría de los miembros presentes en el Congreso de Diputadas y Diputados al momento de su votación.
 2. En caso de tratarse de una ley de acuerdo regional, la Presidencia del Congreso enviará el proyecto aprobado a la Cámara de las Regiones para continuar con su tramitación.
 3. Terminada la tramitación del proyecto en el Congreso de Diputadas y Diputados, será despachado a la Presidenta o al Presidente de la República para efectos de su promulgación o devolución.
 
-### Artículo 271
+### Artículo 271
 
 Las leyes referidas a la organización, el funcionamiento y los procedimientos del Poder Legislativo y de los Sistemas de Justicia; a los procesos electorales y plebiscitarios; a la regulación de los estados de excepción constitucional; a la regulación de las organizaciones políticas; y aquellas que regulen a la Contraloría General de la República, a la Defensoría del Pueblo, a la Defensoría de la Naturaleza, al Servicio Electoral, a la Corte Constitucional y al Banco Central deberán ser aprobadas por el voto favorable de la mayoría de los integrantes en ejercicio del Congreso de Diputadas y Diputados y de la Cámara de las Regiones.
 
-### Artículo 272
+### Artículo 272
 
 1. Recibido por la Cámara de las Regiones un proyecto de ley de acuerdo regional aprobado por el Congreso de Diputadas y Diputados, la Cámara de las Regiones se pronunciará, aprobándolo o rechazándolo. Si lo aprueba, el proyecto será enviado al Congreso para que lo despache a la Presidenta o al Presidente de la República para su promulgación como ley. Si lo rechaza, lo tramitará y propondrá al Congreso las enmiendas que considere pertinentes.
 2. Si el Congreso rechaza una o más de esas enmiendas u observaciones, se convocará a una comisión mixta que propondrá nuevas enmiendas para resolver la discrepancia. Estas enmiendas serán votadas por la Cámara y luego por el Congreso. Si todas ellas son aprobadas, el proyecto será despachado para su promulgación.
 3. La comisión mixta estará conformada por igual número de diputadas y diputados y de representantes regionales. La ley fijará el mecanismo para designar a los integrantes de la comisión y establecerá el plazo en que deberá informar. De no evacuar su informe dentro de plazo, se entenderá que la comisión mixta mantiene las observaciones originalmente formuladas por la Cámara y rechazadas por el Congreso y se aplicará lo dispuesto en el inciso anterior.
 
-### Artículo 273
+### Artículo 273
 
 1. En la sesión siguiente a su despacho por el Congreso de Diputadas y Diputados y con el voto favorable de la mayoría, la Cámara de las Regiones podrá requerir conocer de un proyecto de ley que no sea de acuerdo regional.
 2. La Cámara contará con sesenta días desde que recibe el proyecto para formularle enmiendas y remitirlas al Congreso. Este podrá aprobarlas o insistir en el proyecto original con el voto favorable de la mayoría. Si dentro del plazo señalado la Cámara no evacúa su informe, el proyecto quedará en condiciones de ser despachado por el Congreso.
 
-### Artículo 274
+### Artículo 274
 
 1. Si la Presidenta o el Presidente de la República aprueba el proyecto despachado por el Congreso de Diputadas y Diputados, dispondrá su promulgación como ley. En caso contrario, lo devolverá dentro de treinta días con las observaciones que estime pertinentes o comunicando su rechazo total al proyecto.
 2. En ningún caso se admitirán las observaciones que no tengan relación directa con las ideas matrices o fundamentales del proyecto, a menos que hubieran sido consideradas en el mensaje respectivo.
@@ -255,13 +255,13 @@ Las leyes referidas a la organización, el funcionamiento y los procedimientos 
 5. En caso de que la Presidenta o el Presidente de la República no devuelva el proyecto dentro de treinta días, contados desde la fecha de su remisión, se entenderá que lo aprueba y se promulgará como ley. La promulgación debe hacerse siempre dentro del plazo de diez días, contados desde que ella sea procedente. La publicación se hará dentro de los cinco días hábiles siguientes a la fecha en que quede totalmente tramitado el decreto promulgatorio.
 6. El proyecto que sea desechado en general por el Congreso de Diputadas y Diputados no podrá renovarse sino después de un año.
 
-### Artículo 275
+### Artículo 275
 
 1. La ley que regule el funcionamiento del Congreso de Diputadas y Diputados deberá establecer los mecanismos para determinar el orden en que se conocerán los proyectos de ley, debiendo distinguir entre urgencia simple, suma urgencia y discusión inmediata.
 2. La ley especificará los casos en que la urgencia será fijada por la Presidenta o el Presidente de la República y por el Congreso de Diputadas y Diputados. La ley especificará los casos y condiciones de la urgencia popular.
 3. Solo quien ejerza la Presidencia de la República contará con la facultad de determinar la discusión inmediata de un proyecto de ley.
 
-### Artículo 276
+### Artículo 276
 
 1. La Cámara de las Regiones conocerá de las propuestas de estatutos regionales aprobados por una asamblea regional, de creación de empresas regionales efectuadas por una o más asambleas regionales de conformidad con lo dispuesto en la Constitución y de delegación de potestades legislativas realizadas por estas.
 2. Recibida una propuesta, la Cámara podrá aprobar el proyecto o efectuar las enmiendas que estime necesarias. De aceptarse las enmiendas por la asamblea regional respectiva, el proyecto quedará en estado de ser despachado al Congreso de Diputadas y Diputados para su tramitación como ley de acuerdo regional. Para el conocimiento de un estatuto regional, el Congreso y la Cámara contarán con un plazo de seis meses.
@@ -269,7 +269,7 @@ Las leyes referidas a la organización, el funcionamiento y los procedimientos 
 4. La ley que delegue potestades señalará las materias precisas sobre las que recaerá la delegación y podrá establecer las limitaciones, restricciones y formalidades que se estimen convenientes.
 5. La Contraloría General de la República tomará razón de las leyes regionales dictadas de conformidad con este artículo, debiendo rechazarlas cuando ellas excedan o contravengan la autorización referida.
 
-### Artículo 277
+### Artículo 277
 
 1. El proyecto de Ley de Presupuestos deberá ser presentado por quien ejerza la Presidencia de la República a lo menos con tres meses de anterioridad a la fecha en que debe empezar a regir.
 2. Si el proyecto no fuera despachado dentro de los noventa días de presentado, regirá el proyecto inicialmente enviado por la Presidenta o el Presidente.
@@ -282,7 +282,7 @@ proporcionalmente todos los gastos, cualquiera que sea su naturaleza.
 8. En la tramitación de la Ley de Presupuestos, así como respecto de los presupuestos regionales y comunales, se deberá garantizar la participación
 popular.
 
-### Artículo 278
+### Artículo 278
 
 1. El Congreso de Diputadas y Diputados y la Cámara de las Regiones contarán con una Unidad Técnica dependiente administrativamente del Congreso.
 2. Su Secretaría Legislativa estará encargada de asesorar en los aspectos jurídicos de las leyes que tramiten. Podrá, asimismo, emitir informes sobre ámbitos de la legislación que hayan caído en desuso o que presenten problemas técnicos.

--- a/Markdown/08 - Poder Ejecutivo.md
+++ b/Markdown/08 - Poder Ejecutivo.md
@@ -1,45 +1,45 @@
 # Capítulo VIII: Poder Ejecutivo
 
-### Artículo 279
+### Artículo 279
 
 1. El gobierno y la administración del Estado corresponden a la Presidenta o al Presidente de la República, quien ejerce la jefatura de Estado y la jefatura de Gobierno.
 2. El 5 de julio de cada año dará cuenta al país del estado administrativo y político de la república ante el Congreso de Diputadas y Diputados y la Cámara de las Regiones, en sesión conjunta.
 
-### Artículo 280
+### Artículo 280
 
 1. Para que una persona sea elegida Presidenta o Presidente de la República se requiere tener nacionalidad chilena y haber cumplido treinta años de edad al día de la elección.
 2. Asimismo, deberá tener residencia efectiva en el territorio nacional los cuatro años anteriores a la elección. No se exigirá este requisito cuando la ausencia del país se deba a que la persona, su cónyuge o su conviviente civil cumplan misión diplomática, trabajen en organismos internacionales o existan otras circunstancias que la justifiquen fundadamente. Tales circunstancias deberán ser calificadas por el Tribunal Calificador de Elecciones.
 3. Al inscribir la candidatura deberá presentar un programa, conforme a la ley.
 
-### Artículo 281
+### Artículo 281
 
 1. La Presidenta o el Presidente se elegirá mediante sufragio universal y directo, por la mayoría absoluta de los votos válidamente emitidos. La elección se efectuará el tercer domingo de noviembre del año anterior a aquel en que deba cesar en el cargo quien esté en funciones.
 2. Si a la elección se presentan más de dos candidaturas y ninguna de ellas obtiene más de la mitad de los sufragios válidamente emitidos, se procederá a una segunda votación entre las candidaturas que hayan obtenido las dos más altas mayorías. Esta votación se realizará el cuarto domingo después de la primera. Será electa la candidatura que obtenga el quorum establecido en el inciso anterior. En el caso de proceder la segunda votación, las candidaturas podrán efectuar modificaciones a su programa hasta una semana antes de ella.
 3. El día de la elección presidencial será feriado irrenunciable.
 4. En caso de muerte de una o de las dos personas a que se refiere el inciso 2, quien ejerza la Presidencia de la República convocará a una nueva elección dentro del plazo de diez días, contado desde la fecha del deceso. La elección se celebrará noventa días después de la convocatoria si ese día corresponde a un domingo. En caso contrario, se realizará el domingo siguiente.
 
-### Artículo 282
+### Artículo 282
 
 1. El proceso de calificación de la elección de la Presidenta o del Presidente deberá quedar concluido dentro de los quince días siguientes a la primera votación y dentro de los treinta siguientes a la segunda.
 2. El Tribunal Calificador de Elecciones comunicará de inmediato al Congreso de Diputadas y Diputados y a la Cámara de las Regiones la proclamación de la Presidenta o del Presidente electo.
 3. El Congreso de Diputadas y Diputados y la Cámara de las Regiones, reunidos en sesión conjunta el día en que deba cesar en su cargo quien se encuentre en funciones, y con los integrantes que asistan, tomará conocimiento de la resolución del Tribunal Calificador de Elecciones que proclama a la persona que haya resultado electa.
 4. En el mismo acto, la Presidenta o el Presidente electo prestará promesa o juramento de desempeñar fielmente su cargo, conservar la independencia de la república, guardar y hacer guardar la Constitución y las leyes, y de inmediato asumirá sus funciones.
 
-### Artículo 283
+### Artículo 283
 
 1. Si la Presidenta electa o el Presidente electo se encuentra impedido para tomar posesión del cargo, asumirá, provisoriamente y con el título de Vicepresidenta o Vicepresidente de la República, quien presida el Congreso de Diputadas y Diputados, la Cámara de las Regiones o la Corte Suprema, en ese orden.
 2. Si el impedimento fuese absoluto o durase indefinidamente, la Vicepresidenta o el Vicepresidente, en los diez días siguientes al acuerdo del Congreso de Diputadas y Diputados, convocará a una nueva elección presidencial que se celebrará noventa días después si ese día corresponde a un domingo, o el domingo inmediatamente siguiente, conforme a las reglas generales. Quien así se elija asumirá sus funciones en la oportunidad que señale la ley y durará en ellas el resto del período ya iniciado.
 
-### Artículo 284
+### Artículo 284
 
 1. La Presidenta o el Presidente durará cuatro años en el ejercicio de sus funciones, tras los cuales se podrá reelegir, de forma inmediata o posterior, solo una vez.
 2. Si postula a la reelección inmediata, desde el día de la inscripción de su candidatura, no podrá ejecutar gasto que no sea de mera administración ni realizar actividades públicas que conlleven propaganda a su campaña para la reelección. La Contraloría General de la República dictará un instructivo que regule las situaciones descritas en este artículo.
 
-### Artículo 285
+### Artículo 285
 
 Cuando por enfermedad, ausencia del territorio de la república u otro grave motivo, la Presidenta o el Presidente de la República no pudiera ejercer su cargo, le subrogará, con el título de Vicepresidenta o Vicepresidente de la República, la ministra o el ministro de Estado que corresponda, según el orden de precedencia legal.
 
-### Artículo 286
+### Artículo 286
 
 1. Son impedimentos definitivos para el ejercicio del cargo de Presidenta o Presidente de la República y causan su vacancia: la muerte; enfermedad grave, debidamente acreditada, que haga imposible el desempeño del cargo por el resto del período, y así lo califique el Tribunal Calificador de Elecciones; la dimisión aceptada por el Congreso de Diputadas y Diputados, y la destitución por acusación constitucional, conforme a las reglas establecidas en esta Constitución.
 2. En caso de impedimento definitivo, asumirá como subrogante la ministra o el ministro de Estado que se indica en el artículo anterior y se procederá conforme a los incisos siguientes.
@@ -47,7 +47,7 @@ Cuando por enfermedad, ausencia del territorio de la república u otro grave mo
 4. Si la vacancia se produce faltando dos años o más para la siguiente elección presidencial, la Vicepresidenta o el Vicepresidente, dentro de los diez primeros días de su subrogancia, convocará a una elección presidencial para ciento veinte días después de la convocatoria, si ese día corresponde a un domingo, o el domingo siguiente, conforme a las reglas generales. Quien resulte elegido asumirá su cargo el décimo día después de su proclamación, y hasta completar el período que restaba a quien se reemplaza.
 5. La Vicepresidenta o el Vicepresidente que subrogue y la Presidenta o el Presidente que se nombre conforme a lo dispuesto en el inciso anterior tendrán todas las atribuciones que esta Constitución confiere a la Presidenta o al Presidente de la República.
 
-### Artículo 287
+### Artículo 287
 
 Son atribuciones de quien ejerce la Presidencia de la República:
 
@@ -73,13 +73,13 @@ esta Constitución.
 - q) Pedir, indicando los motivos, que se cite a sesión especial al Congreso de Diputadas y Diputados o a la Cámara de las Regiones. En tal caso, la sesión deberá celebrarse a la brevedad posible.
 - r) Las demás establecidas en la Constitución y la ley.
 
-### Artículo 288
+### Artículo 288
 
 1. Quien ejerza la Presidencia de la República tiene la potestad de dictar aquellos reglamentos, decretos e instrucciones que considere necesarios para la ejecución de las leyes.
 2. Asimismo, puede ejercer la potestad reglamentaria en todas aquellas materias que no estén reservadas exclusivamente a la ley. Cuando sean aplicables reglas de rango legal y reglamentario, primará la ley en caso de contradicción.
 3. La Presidenta o el Presidente deberá informar mensualmente al Congreso sobre los reglamentos, decretos e instrucciones que se hayan dictado en virtud del inciso anterior.
 
-### Artículo 289
+### Artículo 289
 
 1. Corresponde a la Presidenta o al Presidente de la República la atribución de negociar, concluir, firmar y ratificar tratados internacionales.
 2. En aquellos casos en que los tratados internacionales se refieran a materias de ley, ellos deberán ser aprobados por el Poder Legislativo. No requerirán esta aprobación los celebrados en cumplimiento de una ley.
@@ -95,44 +95,44 @@ esta Constitución.
 12. Al negociar los tratados o instrumentos internacionales de inversión o similares, quien ejerza la Presidencia de la República procurará que las instancias de resolución de controversias sean imparciales, independientes y preferentemente permanentes.
 13. Quienes habiten el territorio o las chilenas y los chilenos que se encuentren en el exterior y hayan cumplido los dieciséis años de edad tendrán iniciativa para solicitar a la Presidenta o al Presidente de la República la suscripción de tratados internacionales de derechos humanos de acuerdo con los requisitos que establezca la ley, la que definirá el plazo dentro del cual la o el Presidente deberá dar respuesta a la referida solicitud.
 
-### Artículo 290
+### Artículo 290
 
 1. Las ministras y los ministros de Estado son colaboradores directos e inmediatos de la Presidenta o del Presidente de la República en el gobierno y administración del Estado.
 2. Son responsables de la conducción de sus respectivas carteras, de los actos que firmen y solidariamente de los que suscriban o acuerden con titulares de otros ministerios.
 3. La ley determinará el número y organización de los ministerios, así como el orden de precedencia de las ministras y los ministros titulares.
 4. La Presidenta o el Presidente de la República podrá encomendar a una o más ministras o ministros la coordinación de la labor que corresponde a las secretarias y los secretarios de Estado y las relaciones del Gobierno con el Congreso de Diputadas y Diputados y la Cámara de las Regiones.
 
-### Artículo 291
+### Artículo 291
 
 1. Para ser nombrado ministro o ministra de Estado se requiere ser ciudadano o ciudadana con derecho a sufragio y cumplir con los requisitos generales para el ingreso a la Administración pública.
 2. Se subrogarán o reemplazarán, en caso de ausencia, impedimento, renuncia o cuando por otra causa se produzca la vacancia del cargo, de acuerdo con lo que establece la ley.
 
-### Artículo 292
+### Artículo 292
 
 1. Los reglamentos y decretos de la Presidenta o del Presidente de la República deberán firmarse por la ministra o el ministro de Estado correspondiente y no serán obedecidos sin este requisito.
 2. Los decretos e instrucciones podrán expedirse con la sola firma de la ministra o del ministro de Estado respectivo, por orden de la Presidenta o del Presidente de la República, conforme lo establezca la ley.
 
-### Artículo 293
+### Artículo 293
 
 1. Las ministras y los ministros podrán asistir a las sesiones del Congreso de Diputadas y Diputados y de la Cámara de las Regiones y tomar parte en sus debates, con preferencia para hacer uso de la palabra.
 2. Sin perjuicio de lo anterior, concurrirán personal y obligatoriamente a las sesiones especiales que convoque el Congreso o la Cámara para informarse sobre asuntos que, perteneciendo al ámbito de atribuciones de las correspondientes secretarías de Estado, acuerden tratar.
 
-### Artículo 294
+### Artículo 294
 
 La designación de quienes representen a los ministerios y servicios públicos con presencia en la región autónoma será decisión de la Presidencia de la República.
 
-### Artículo 295
+### Artículo 295
 
 1. El Estado tiene el monopolio indelegable del uso legítimo de la fuerza, la que ejerce a través de las instituciones competentes, conforme a esta Constitución, las leyes y con respeto a los derechos humanos.
 2. La ley regulará el uso de la fuerza y el armamento que pueda ser utilizado en el ejercicio de las funciones de las instituciones autorizadas por esta Constitución.
 3. Ninguna persona, grupo u organización podrá poseer, tener o portar armas u otros elementos similares, salvo en los casos que señale la ley, la que fijará los requisitos, las autorizaciones y los controles del uso, del porte y de la tenencia de armas.
 
-### Artículo 296
+### Artículo 296
 
 1. A la Presidenta o al Presidente de la República le corresponde la conducción de la seguridad pública a través del ministerio correspondiente.
 2. La disposición, la organización y los criterios de distribución de las policías se establecerán en la Política Nacional de Seguridad Pública. La ley regulará la vigencia, los alcances y los mecanismos de elaboración y aprobación de dicha política, la que deberá comprender la perspectiva de género y de interculturalidad y el pleno respeto al derecho internacional y los derechos fundamentales.
 
-### Artículo 297
+### Artículo 297
 
 1. Las policías dependen del ministerio a cargo de la seguridad pública y son instituciones policiales, no militares, de carácter centralizado, con competencia en todo el territorio de Chile, y están destinadas para garantizar la seguridad pública, dar eficacia al derecho y resguardar los derechos fundamentales, en el marco de sus competencias.
 2. Las policías deberán incorporar la perspectiva de género en el desempeño de sus funciones y promover la paridad en espacios de toma de decisión. En el uso de la fuerza, deberán actuar respetando los principios de legalidad, necesidad, precaución, proporcionalidad, no discriminación y rendición de cuentas, con respeto al derecho internacional y los derechos fundamentales garantizados en esta Constitución.
@@ -140,12 +140,12 @@ La designación de quienes representen a los ministerios y servicios públicos
 4. Las policías y sus integrantes estarán sujetos a controles en materia de probidad y transparencia en la forma y condiciones que determinen la Constitución y la ley. Sus integrantes no podrán pertenecer a partidos políticos; asociarse en organizaciones políticas, gremiales o sindicales; ejercer el derecho a huelga, ni postularse a cargos de elección popular.
 5. El ingreso y la formación en las policías será gratuito y no discriminatorio, del modo que establezca la ley. La educación y formación policial se funda en el respeto a los derechos humanos.
 
-### Artículo 298
+### Artículo 298
 
 1. A la Presidenta o al Presidente de la República le corresponde la conducción de la defensa nacional y desempeña la jefatura suprema de las Fuerzas Armadas. Ejercerá el mando a través del ministerio a cargo de la defensa nacional.
 2. La disposición, la organización y los criterios de distribución de las Fuerzas Armadas se establecerán en la Política de Defensa Nacional y la Política Militar. La ley regulará la vigencia, los alcances y los mecanismos de elaboración y aprobación de dichas políticas, las que deberán incorporar los principios de cooperación internacional, de igualdad de género y de interculturalidad y el pleno respeto al derecho internacional y los derechos fundamentales.
 
-### Artículo 299
+### Artículo 299
 
 1. Las Fuerzas Armadas están integradas única y exclusivamente por el Ejército, la Armada y la Fuerza Aérea. Dependen del ministerio a cargo de la defensa nacional y son instituciones destinadas al resguardo de la soberanía, independencia e integridad territorial de la república ante agresiones de carácter externo, según lo establecido en la Carta de Naciones Unidas. Colaboran con la paz y seguridad internacional, conforme a la Política de Defensa Nacional.
 2. Estas deben incorporar la perspectiva de género en el desempeño de sus funciones, promover la paridad en espacios de toma de decisión y actuar con respeto al derecho internacional y a los derechos fundamentales garantizados en la Constitución.
@@ -154,12 +154,12 @@ La designación de quienes representen a los ministerios y servicios públicos
 5. El ingreso y la formación en las Fuerzas Armadas será gratuito y no discriminatorio, en el modo que establezca la ley. La educación militar se funda en el respeto a los derechos humanos.
 6. La ley regulará la organización de la defensa, su institucionalidad, su estructura y empleo conjunto, sus jefaturas, su mando y la carrera militar.
 
-### Artículo 300
+### Artículo 300
 
 1. Solo se podrá suspender o limitar el ejercicio de los derechos y las garantías que la Constitución asegura a todas las personas bajo las siguientes situaciones de excepción: conflicto armado internacional, conflicto armado interno según establece el derecho internacional o calamidad pública. No podrán restringirse o suspenderse sino los derechos y garantías expresamente señalados en la Constitución.
 2. La declaración y renovación de los estados de excepción constitucional respetará los principios de proporcionalidad y necesidad y se limitarán, respecto de su duración, extensión y medios empleados, a lo que sea estrictamente necesario para la más pronta restauración de la normalidad constitucional.
 
-### Artículo 301
+### Artículo 301
 
 1. El estado de asamblea, en caso de conflicto armado internacional, y el estado de sitio, en caso de conflicto armado interno, serán declarados por la Presidenta o el Presidente de la República con la autorización del Congreso de Diputadas y Diputados y de la Cámara de las Regiones, en sesión conjunta. La declaración deberá determinar las zonas afectadas por el estado de excepción correspondiente.
 2. El Congreso de Diputadas y Diputados y la Cámara de las Regiones, en sesión conjunta, dentro del plazo de veinticuatro horas contadas desde el momento en que la Presidenta o el Presidente de la República someta la declaración de estado de asamblea o de sitio a su consideración, deberá pronunciarse por la mayoría de sus miembros aceptando o rechazando la proposición. En su solicitud y posterior declaración se deberán especificar los fundamentos que justifiquen la extrema necesidad de la declaración, pudiendo el Congreso y la Cámara solamente introducir modificaciones respecto de su extensión territorial. Si el Congreso y la Cámara no se pronuncian dentro de dicho plazo, serán citados por el solo ministerio de la Constitución a sesiones especiales diarias, hasta que se pronuncien sobre la declaración.
@@ -169,7 +169,7 @@ La designación de quienes representen a los ministerios y servicios públicos
 6. Por la declaración del estado de sitio, la Presidenta o el Presidente de la República podrá restringir la libertad de circulación y el derecho de asociación. Podrá, además, suspender o restringir el ejercicio del derecho de reunión.
 7. El estado de asamblea mantendrá su vigencia por el tiempo que se extienda la situación de conflicto armado internacional, salvo que la Presidenta o el Presidente de la República disponga su término con anterioridad o el Congreso de Diputadas y Diputados y la Cámara de las Regiones retiren su autorización.
 
-### Artículo 302
+### Artículo 302
 
 1. El estado de catástrofe, en caso de calamidad pública, será declarado por la Presidenta o el Presidente de la República. La declaración deberá establecer el ámbito de aplicación y el plazo de duración, el que no podrá ser mayor a treinta días. Solo con acuerdo del Congreso de Diputadas y Diputados podrá extenderse más allá de este plazo. El referido acuerdo se tramitará en la forma establecida en el inciso 2 del artículo anterior.
 2. La Presidenta o el Presidente de la República estará obligado a informar al Congreso de Diputadas y Diputados de las medidas adoptadas.
@@ -177,7 +177,7 @@ La designación de quienes representen a los ministerios y servicios públicos
 4. La Presidenta o el Presidente de la República podrá solicitar la prórroga del estado de catástrofe, para lo cual requerirá la aprobación, en sesión conjunta, de la mayoría de integrantes en ejercicio del Congreso de Diputadas y Diputados y de la Cámara de las Regiones.
 5. Por la declaración del estado de catástrofe, la Presidenta o el Presidente de la República podrá restringir la libertad de circulación y el derecho de reunión. Podrá, asimismo, disponer requisiciones de bienes, establecer limitaciones al ejercicio del derecho de propiedad y adoptar todas las medidas extraordinarias de carácter legal y administrativo que sean necesarias para el pronto restablecimiento de la normalidad en la zona afectada.
 
-### Artículo 303
+### Artículo 303
 
 1. Los actos de la Presidenta o del Presidente de la República o de la jefa o del jefe de estado de excepción que tengan por fundamento la declaración del estado de excepción constitucional deberán señalar expresamente los derechos constitucionales que suspendan o restrinjan.
 2. El decreto de declaración deberá indicar específicamente las medidas a adoptarse en razón de la excepción, las que deberán ser proporcionales a los fines establecidos en la declaración de excepción y no limitar excesivamente o impedir de manera total el legítimo ejercicio de cualquier derecho establecido en esta Constitución. Los estados de excepción constitucional permitirán a la Presidenta o al Presidente de la República el ejercicio de potestades y competencias ordinariamente reservadas al nivel regional o comunal cuando el restablecimiento de la normalidad así lo requiera.
@@ -185,16 +185,16 @@ La designación de quienes representen a los ministerios y servicios públicos
 4. Las Fuerzas Armadas y policías deberán cumplir estrictamente las órdenes de la jefa o del jefe de estado de excepción a cargo.
 5. Las medidas que se adopten durante los estados de excepción no podrán, bajo ninguna circunstancia, prolongarse más allá de su vigencia.
 
-### Artículo 304
+### Artículo 304
 
 1. La ley regulará los estados de excepción, su declaración y la aplicación de las medidas legales y administrativas que procediera adoptar bajo ellos, en todo lo no regulado por esta Constitución. Dicha ley no podrá afectar las competencias y el funcionamiento de los órganos constitucionales, ni los derechos ni las inmunidades de sus respectivos titulares.
 2. Asimismo, esta ley regulará el modo en el que la Presidenta o el Presidente de la República y las autoridades que este encomiende rendirán cuenta detallada, veraz y oportuna al Congreso de Diputadas y Diputados de las medidas adoptadas y de los planes para la superación de la situación de excepción, así como de los hechos de gravedad que hubieran surgido con ocasión del estado de excepción constitucional. La omisión de este deber de rendición de cuentas se considerará una infracción a la Constitución.
 
-### Artículo 305
+### Artículo 305
 
 1. Una vez declarado el estado de excepción, se constituirá una Comisión de Fiscalización dependiente del Congreso de Diputadas y Diputados, de composición paritaria y plurinacional, integrada por diputadas y diputados, por representantes regionales y por representantes de la Defensoría del Pueblo, en la forma que establezca la ley. Dicho órgano deberá fiscalizar las medidas adoptadas bajo el estado de excepción, para lo cual emitirá informes periódicos que contengan un análisis de ellas, su proporcionalidad y la observancia de los derechos humanos y tendrá las demás atribuciones que le encomiende la ley.
 2. Los órganos del Estado deben colaborar y aportar todos los antecedentes requeridos por la Comisión para el desempeño de sus funciones. En caso de que tome conocimiento de vulneraciones a lo dispuesto en esta Constitución o la ley, debe efectuar las denuncias pertinentes, las cuales serán remitidas y conocidas por los órganos competentes. La ley regulará su integración y funcionamiento.
 
-### Artículo 306
+### Artículo 306
 
 Las medidas adoptadas en ejercicio de las facultades conferidas en los estados de excepción constitucional podrán ser objeto de revisión por los tribunales de justicia tanto en su mérito como en su forma. Las requisiciones que se practiquen darán lugar a indemnizaciones conforme a la ley.

--- a/Markdown/09 - Sistemas de Justicia.md
+++ b/Markdown/09 - Sistemas de Justicia.md
@@ -6,16 +6,16 @@
 2. Se ejerce exclusivamente por los tribunales de justicia y las autoridades de los pueblos y naciones indígenas reconocidos por la Constitución o las leyes dictadas conforme a ella.
 3. El ejercicio de la jurisdicción debe velar por la tutela y promoción de los derechos humanos y de la naturaleza, del sistema democrático y el principio de juridicidad.
 
-### Artículo 308
+### Artículo 308
 
 Los tribunales de justicia se estructuran conforme al principio de unidad jurisdiccional como base de su organización y funcionamiento y están sujetos al mismo estatuto jurídico y a los mismos principios.
 
-### Artículo 309
+### Artículo 309
 
 1. El Estado reconoce los sistemas jurídicos de los pueblos y naciones indígenas, los que en virtud de su derecho a la libre determinación coexisten coordinados en un plano de igualdad con el Sistema Nacional de Justicia. Estos deberán respetar los derechos fundamentales que establecen esta Constitución y los tratados e instrumentos internacionales sobre derechos humanos de los que Chile es parte.
 2. La ley determinará los mecanismos de coordinación, de cooperación y de resolución de conflictos de competencia entre los sistemas jurídicos indígenas y las entidades estatales.
 
-### Artículo 310
+### Artículo 310
 
 1. Las juezas y jueces que ejercen jurisdicción son independientes entre sí y de todo otro poder o autoridad, debiendo actuar y resolver de forma imparcial. En sus providencias, solo están sometidos al imperio de la ley.
 2. La función jurisdiccional la ejercen exclusivamente los tribunales establecidos por ley. Ningún otro órgano del Estado, persona o grupo de personas, podrán ejercer la función jurisdiccional, conocer causas pendientes, modificar los fundamentos o el contenido de las resoluciones judiciales o reabrir procesos concluidos.
@@ -23,150 +23,150 @@ Los tribunales de justicia se estructuran conforme al principio de unidad jurisd
 4. Las juezas y jueces solo ejercerán la función jurisdiccional, no pudiendo desempeñar función administrativa ni legislativa alguna.
 5. Las juezas y jueces no podrán militar en partidos políticos.
 
-### Artículo 311
+### Artículo 311
 
 1. La función jurisdiccional debe ejercerse bajo un enfoque interseccional y debe garantizar la igualdad sustantiva y el cumplimiento de las obligaciones internacionales de derechos humanos en la materia.
 2. Este deber es extensivo a todo órgano jurisdiccional y auxiliar, a funcionarias y funcionarios del Sistema Nacional de Justicia, durante todo el curso del proceso y en todas las actuaciones que realicen.
 
-### Artículo 312
+### Artículo 312
 
 1. La función jurisdiccional se regirá por los principios de paridad y perspectiva de género. Todos los órganos y personas que intervienen en la función jurisdiccional deben garantizar la igualdad sustantiva.
 2. El Estado garantiza que los nombramientos en el Sistema Nacional de Justicia respeten el principio de paridad en todos los órganos de la jurisdicción, incluyendo la designación de las presidencias.
 3. Los tribunales, cualquiera sea su competencia, deben resolver con enfoque de género.
 4. Los sistemas de justicia deben adoptar todas las medidas para prevenir, sancionar y erradicar la violencia contra mujeres, diversidades y disidencias sexuales y de género, en todas sus manifestaciones y ámbitos.
 
-### Artículo 313
+### Artículo 313
 
 Las juezas y los jueces no podrán ser acusados o privados de libertad, salvo en caso de delito flagrante, si la corte de apelaciones correspondiente no declara admisible uno o más capítulos de la acusación respectiva. La resolución que se pronuncie acerca de la querella de capítulos será apelable ante la Corte Suprema. Encontrándose firme la resolución que acoge la querella, el procedimiento penal continuará de acuerdo con las reglas generales y la jueza o el juez quedará suspendido del ejercicio de sus funciones.
 
-### Artículo 314
+### Artículo 314
 
 Las juezas y los jueces son inamovibles. No pueden ser suspendidos, trasladados o removidos, sino conforme a las causales y procedimientos establecidos por la Constitución y las leyes.
 
-### Artículo 315
+### Artículo 315
 
 Las juezas y los jueces son personalmente responsables por los delitos de cohecho, falta de observancia en materia sustancial de las leyes que reglan el procedimiento y, en general, por toda prevaricación, denegación o torcida administración de justicia. La ley determinará los casos y el modo de hacer efectiva esta responsabilidad.
 
-### Artículo 316
+### Artículo 316
 
 Las juezas y los jueces cesan en sus cargos por cumplir los setenta años de edad, por renuncia, por constatarse una incapacidad legal sobreviniente o por remoción.
 
-### Artículo 317
+### Artículo 317
 
 1. Reclamada su intervención en la forma legal y sobre materias de su competencia, los tribunales no podrán excusarse de ejercer su función en un tiempo razonable ni aun a falta de norma jurídica expresa que resuelva el asunto sometido a su decisión.
 2. El ejercicio de la jurisdicción es indelegable.
 
-### Artículo 318
+### Artículo 318
 
 1. Para hacer ejecutar las resoluciones y practicar o hacer practicar las actuaciones que determine la ley, los tribunales de justicia podrán impartir órdenes o instrucciones directas a la fuerza pública. Estas deben cumplir lo mandatado de forma rápida y expedita, sin que puedan calificar su fundamento, oportunidad o legalidad.
 2. Las sentencias dictadas contra el Estado de Chile por tribunales internacionales de derechos humanos cuya jurisdicción ha sido reconocida por este serán cumplidas por los tribunales de justicia conforme al procedimiento establecido por la ley, aun si aquellas contravienen una sentencia firme pronunciada por estos.
 
-### Artículo 319
+### Artículo 319
 
 1. Las sentencias deberán ser siempre fundadas y redactadas en un lenguaje claro e inclusivo. La ley podrá establecer excepciones al deber de fundamentación de las resoluciones judiciales.
 2. Todas las etapas de los procedimientos y las resoluciones judiciales son públicas. Excepcionalmente, la ley podrá establecer su reserva o secreto en casos calificados.
 
-### Artículo 320
+### Artículo 320
 
 1. El acceso a la función jurisdiccional será gratuito, sin perjuicio de las actuaciones judiciales y sanciones procesales establecidas por la ley.
 2. La justicia arbitral será siempre voluntaria. La ley no podrá establecer arbitrajes forzosos.
 
-### Artículo 321
+### Artículo 321
 
 La función jurisdiccional se basa en los principios rectores de la justicia abierta, que se manifiesta en la transparencia, participación y colaboración, con el fin de garantizar el Estado de derecho, promover la paz social y fortalecer la democracia.
 
-### Artículo 322
+### Artículo 322
 
 1. La función jurisdiccional se define en su estructura, integración y procedimientos conforme a los principios de plurinacionalidad, pluralismo jurídico e interculturalidad.
 2. Cuando se trate de personas indígenas, los tribunales y sus funcionarios deberán adoptar una perspectiva intercultural en el tratamiento y resolución de las materias de su competencia, tomando debidamente en consideración las costumbres, las tradiciones, los protocolos y los sistemas normativos de los pueblos indígenas, conforme a los tratados e instrumentos internacionales de derechos humanos de los que Chile es parte.
 
-### Artículo 323
+### Artículo 323
 
 1. Es deber del Estado promover e implementar mecanismos colaborativos de resolución de conflictos que garanticen la participación activa y el diálogo.
 2. Solo la ley podrá determinar los requisitos y efectos de los mecanismos alternativos de resolución de conflictos.
 
-### Artículo 324
+### Artículo 324
 
 1. Las personas que ejercen jurisdicción en órganos unipersonales o colegiados se denominan juezas o jueces. No existirá jerarquía entre quienes ejercen jurisdicción y solo se diferenciarán por la función que desempeñen. Además, no recibirán tratamiento honorífico alguno.
 2. Solo la ley podrá establecer cargos de juezas y jueces. La Corte Suprema y las cortes de apelaciones solo podrán ser integradas por personas que tengan la calidad de juezas o jueces titulares, interinos, suplentes o subrogantes.
 3. La planta de personal y organización administrativa interna de los tribunales será establecida por la ley.
 
-### Artículo 325
+### Artículo 325
 
 El Sistema Nacional de Justicia gozará de autonomía financiera. Anualmente, se destinarán en la Ley de Presupuestos los fondos necesarios para su adecuado funcionamiento.
 
-### Artículo 326
+### Artículo 326
 
 Los tribunales deberán cumplir con el principio de proximidad e itinerancia. Con la finalidad de garantizar el acceso a la justicia y a la tutela jurisdiccional efectiva, podrán funcionar en localidades situadas fuera de su lugar de asiento, siempre dentro del territorio de su competencia.
 
-### Artículo 327
+### Artículo 327
 
 El Sistema Nacional de Justicia está integrado por la justicia vecinal, los tribunales de instancia, las cortes de apelaciones y la Corte Suprema.
 
-### Artículo 328
+### Artículo 328
 
 1. La Corte Suprema es un órgano colegiado con jurisdicción en todo el país que tiene como función velar por la correcta aplicación del derecho y uniformar su interpretación, así como las demás atribuciones que establezcan esta Constitución y la ley.
 2. Se compondrá de veintiún juezas y jueces y funcionará en pleno o salas especializadas.
 3. Sus juezas y jueces durarán en sus cargos un máximo de catorce años, sin posibilidad de reelección.
 4. La presidencia de la Corte Suprema será ejercida por una persona elegida por sus pares. Durará en sus funciones dos años sin posibilidad de ejercer nuevamente el cargo. Quien ejerza la Presidencia no podrá integrar ninguna de las salas.
 
-### Artículo 329
+### Artículo 329
 
 La Corte Suprema conocerá y resolverá las impugnaciones deducidas en contra de las decisiones de la jurisdicción indígena, lo hará en sala especializada y asistida por una consejería técnica integrada por expertos en su cultura y derecho propio, en la forma que establezca la ley.
 
-### Artículo 330
+### Artículo 330
 
 1. Las cortes de apelaciones son órganos colegiados con jurisdicción sobre una región o parte de ella. Su función principal es resolver las impugnaciones de las resoluciones dictadas por los tribunales de instancia, así como las demás competencias que establezcan la Constitución y la ley.
 2. Funcionarán en pleno o en salas preferentemente especializadas.
 3. La presidencia de cada corte de apelaciones será ejercida por una persona elegida por sus pares. Durará en sus funciones dos años.
 
-### Artículo 331
+### Artículo 331
 
 1. Son tribunales de instancia los civiles, penales, de familia, laborales, de competencia común o mixtos, administrativos, ambientales, vecinales, de ejecución de pena y los demás que establezcan la Constitución y ley.
 2. La organización, las atribuciones, la competencia y el número de juezas o jueces que integran estos tribunales son determinados por la ley.
 
-### Artículo 332
+### Artículo 332
 
 1. Los tribunales administrativos conocen y resuelven las acciones dirigidas en contra de la Administración del Estado o promovidas por esta y las demás materias que establezca la ley.
 2. Para su conocimiento y resolución la ley establecerá un procedimiento unificado, simple y expedito.
 3. Habrá al menos un tribunal administrativo en cada región del país y podrán funcionar en salas especializadas.
 4. Los asuntos de competencia de estos tribunales no podrán ser sometidos a arbitraje.
 
-### Artículo 333
+### Artículo 333
 
 1. Los tribunales ambientales conocerán y resolverán acerca de la legalidad de los actos administrativos en materia ambiental, de la acción de tutela de derechos de la naturaleza y derechos ambientales, de la reparación por daño ambiental y las demás que señalen la Constitución y la ley.
 2. Habrá al menos un tribunal ambiental en cada región del país.
 3. La ley regulará la integración, competencia y demás aspectos que sean necesarios para su adecuado funcionamiento.
 4. Las acciones para impugnar la legalidad de los actos administrativos que se pronuncien sobre materia ambiental y la solicitud de medidas cautelares podrán interponerse directamente ante los tribunales ambientales, sin que pueda exigirse el agotamiento previo de la vía administrativa.
 
-### Artículo 334
+### Artículo 334
 
 1. La justicia vecinal se compone de los juzgados vecinales y los centros de justicia vecinal.
 2. En cada comuna del país que sea asiento de una municipalidad habrá, a lo menos, un juzgado vecinal que ejercerá la función jurisdiccional respecto de todas aquellas controversias jurídicas que se susciten a nivel comunal que no sean competencia de otro tribunal y de los demás asuntos que la ley les encomiende, conforme a un procedimiento breve, oral, simple y expedito.
 
-### Artículo 335
+### Artículo 335
 
 1. Los centros de justicia vecinal son órganos encargados de promover la solución de conflictos vecinales y de pequeña cuantía dentro de una comunidad determinada por ley, sobre la base del diálogo social, la paz y la participación de las partes involucradas. Se debe priorizar su instalación en zonas rurales y lugares alejados de áreas urbanas.
 2. Los centros de justicia vecinal deberán orientar e informar al público en materias jurídicas, haciendo las derivaciones que fuesen necesarias, así como ejercer las demás funciones que la ley les encomiende.
 3. La organización, atribuciones, materias y procedimientos que correspondan a los centros de justicia vecinal se regirán por la ley respectiva.
 
-### Artículo 336
+### Artículo 336
 
 1. Los tribunales de ejecución de penas velarán por los derechos fundamentales de las personas condenadas o sujetas a medidas de seguridad, conforme a lo reconocido en esta Constitución y a los tratados e instrumentos internacionales de derechos humanos, procurando su integración e inserción social.
 2. Ejercerán funciones jurisdiccionales en materia de ejecución de penas y medidas de seguridad, control jurisdiccional de la potestad disciplinaria de las autoridades penitenciarias, protección de los derechos y beneficios de los internos en los establecimientos penitenciarios y demás que señale la ley.
 
-### Artículo 337
+### Artículo 337
 
 1. El sistema de cumplimiento de las sanciones penales y de las medidas de seguridad se organizará sobre la base del respeto a los derechos humanos y tendrá como objetivos el cumplimiento de la pena y la integración e inserción social de la persona que cumpla una condena judicial.
 2. Es deber del Estado, en su especial posición de garante frente a las personas privadas de libertad, velar por la protección y ejercicio efectivo de sus derechos fundamentales consagrados en esta Constitución y en los tratados e instrumentos internacionales sobre derechos humanos.
 
-### Artículo 338
+### Artículo 338
 
 1. Solo el Estado puede ejecutar el cumplimiento de penas y medidas privativas de libertad, a través de instituciones públicas especialmente establecidas para estos fines. Esta función no podrá ser cumplida por privados.
 2. Para la inserción, integración y reparación de las personas privadas de libertad, los establecimientos penitenciarios deben contar con espacios para el estudio, el trabajo, el deporte, las artes y las culturas.
 3. En el caso de mujeres y personas gestantes y madres de lactantes, el Estado adoptará las medidas necesarias, tales como infraestructura y equipamiento, en los regímenes de control cerrado, abierto y pospenitenciario.
 
-### Artículo 339
+### Artículo 339
 
 1. El Tribunal Calificador de Elecciones conocerá del escrutinio general y de la calificación de las elecciones de las autoridades electas por votación popular a nivel nacional, resolverá las reclamaciones que se susciten y proclamará a los que resulten elegidas y elegidos.
 2. Además, conocerá y resolverá los reclamos administrativos que se entablen contra actos del Servicio Electoral y las decisiones emanadas de tribunales supremos u órganos equivalentes de las organizaciones políticas.
@@ -177,7 +177,7 @@ La Corte Suprema conocerá y resolverá las impugnaciones deducidas en contra 
 7. Una ley regulará la organización y el funcionamiento del Tribunal Calificador
 de Elecciones, su planta, remuneraciones y estatuto del personal.
 
-### Artículo 340
+### Artículo 340
 
 1. Los tribunales electorales regionales están encargados de conocer el escrutinio general y la calificación de las elecciones de nivel regional, comunal y de organismos de la sociedad civil y demás organizaciones reconocidas por esta Constitución o por la ley, así como resolver las reclamaciones a que den lugar y proclamar las candidaturas que resulten electas.
 2. Conocerán, asimismo, de los plebiscitos regionales y comunales, sin perjuicio de las demás atribuciones que determine la ley.
@@ -186,18 +186,18 @@ de Elecciones, su planta, remuneraciones y estatuto del personal.
 5. Estos tribunales valorarán la prueba conforme a las reglas de la sana crítica.
 6. Una ley regulará la organización y el funcionamiento de los tribunales electorales regionales, plantas, remuneraciones y estatuto del personal.
 
-### Artículo 341
+### Artículo 341
 
 La gestión administrativa y la superintendencia directiva y correccional del Tribunal Calificador de Elecciones y de los tribunales electorales regionales corresponderá al Consejo de la Justicia.
 
 ## Consejo de la Justicia
 
-### Artículo 342
+### Artículo 342
 
 1. El Consejo de la Justicia es un órgano autónomo, técnico, paritario y plurinacional, con personalidad jurídica y patrimonio propio, cuya finalidad es fortalecer la independencia judicial. Está encargado de los nombramientos, gobierno, gestión, formación y disciplina en el Sistema Nacional de Justicia.
 2. En el ejercicio de sus atribuciones debe considerar el principio de no discriminación, la inclusión, la paridad de género, la equidad territorial y la plurinacionalidad.
 
-### Artículo 343
+### Artículo 343
 
 Son atribuciones del Consejo de la Justicia:
 
@@ -214,7 +214,7 @@ Son atribuciones del Consejo de la Justicia:
 - k) Dictar instrucciones relativas a la organización y gestión administrativa de los tribunales. Estas instrucciones podrán tener un alcance nacional, regional o local.
 - l) Las demás atribuciones que encomienden esta Constitución y la ley.
 
-### Artículo 344
+### Artículo 344
 
 1. El Consejo de la Justicia se compone de diecisiete integrantes, conforme a la siguiente integración:
     - a) Ocho juezas o jueces titulares elegidos por sus pares.
@@ -224,29 +224,29 @@ Son atribuciones del Consejo de la Justicia:
 2. Durarán seis años en sus cargos y no podrán reelegirse. Se renovarán por parcialidades cada tres años conforme a lo establecido por la ley.
 3. Sus integrantes serán elegidos de acuerdo con criterios de paridad de género, plurinacionalidad y equidad territorial.
 
-### Artículo 345
+### Artículo 345
 
 1. El Consejo de la Justicia podrá funcionar en pleno o en comisiones. En ambos casos, tomará sus decisiones por la mayoría de sus integrantes en ejercicio.
 2. El Consejo se organizará desconcentradamente. La ley determinará la organización, el funcionamiento, los procedimientos de elección de integrantes del Consejo y fijará la planta, el régimen de remuneraciones y el estatuto de su personal.
 
-### Artículo 346
+### Artículo 346
 
 1. Quienes integren el Consejo no podrán ejercer otra función o empleo, sea o no remunerado, con exclusión de las actividades académicas. La ley podrá establecer otras incompatibilidades en el ejercicio del cargo.
 2. Aquellos mencionados en las letras a) y b) del artículo sobre la composición del Consejo quedarán suspendidos del ejercicio de su función mientras dure su cometido.
 3. No podrán concursar para ser designados en cargos judiciales hasta transcurrido un año desde que cesen en sus funciones.
 
-### Artículo 347
+### Artículo 347
 
 1. Quienes integren el Consejo cesarán en su cargo al término de su período, por cumplir setenta años de edad, por remoción, renuncia, incapacidad física o mental sobreviniente o condena por delito que merezca pena aflictiva.
 2. Tanto la renuncia como la incapacidad sobreviniente deberá ser aceptada o constatada, según corresponda, por el Consejo.
 3. El proceso de remoción será determinado por la ley, respetando todas las garantías de un debido proceso.
 
-### Artículo 348
+### Artículo 348
 
 1. El Consejo efectuará los nombramientos mediante concursos públicos regulados por la ley, los que incluirán audiencias públicas.
 2. Para acceder a un cargo de jueza o juez dentro del Sistema Nacional de Justicia se requerirá haber aprobado el curso de habilitación de la Academia Judicial para el ejercicio de la función jurisdiccional; contar con tres años de ejercicio de la profesión de abogada o abogado para el caso de tribunales de instancia; con cinco años para el caso de las cortes de apelaciones, y con veinte años para el caso de la Corte Suprema, y los demás requisitos que establezcan la Constitución y la ley.
 
-### Artículo 349
+### Artículo 349
 
 1. Los procedimientos disciplinarios serán conocidos y resueltos por una comisión compuesta por cinco integrantes del Consejo que se elegirán por sorteo, decisión que será revisable por su pleno a petición del afectado.
 2. La resolución del Consejo que ponga término al procedimiento será impugnable ante la Corte Constitucional.

--- a/Markdown/10 - Órganos Autónomos Constitucionales.md
+++ b/Markdown/10 - Órganos Autónomos Constitucionales.md
@@ -1,19 +1,19 @@
 # Capítulo X: Órganos Autónomos Constitucionales
 
-### Artículo 350
+### Artículo 350
 
 Todos los órganos autónomos se rigen por el principio de paridad. Se promueve la implementación de medidas de acción afirmativa, asegurando que al menos el cincuenta por ciento de sus integrantes sean mujeres.
 
 ## Contraloría General de la República
 
-### Artículo 351
+### Artículo 351
 
 1. La Contraloría General de la República es un órgano técnico, autónomo, con personalidad jurídica y patrimonio propio, encargada de velar por el cumplimiento del principio de probidad en la función pública, ejercer el control de constitucionalidad y legalidad de los actos de la Administración del Estado, incluidos los gobiernos regionales, comunales y demás entidades, organismos y servicios que determine la ley.
 2. Está encargada de fiscalizar y auditar el ingreso, la inversión y el gasto de fondos públicos.
 3. En el ejercicio de sus funciones, no podrá evaluar el mérito o conveniencia de las decisiones políticas o administrativas.
 4. La ley establecerá la organización, el funcionamiento, la planta, los procedimientos y las demás atribuciones de la Contraloría General de la República.
 
-### Artículo 352
+### Artículo 352
 
 1. En el ejercicio del control de constitucionalidad y legalidad, la Contraloría General tomará razón de los decretos, resoluciones y otros actos administrativos o representará su ilegalidad. Deberá darles curso cuando la Presidenta o el Presidente de la República insista con la firma de todas sus ministras y ministros, y enviará copia de los respectivos decretos al Congreso de Diputadas y Diputados.
 2. En ningún caso dará curso a los decretos de gastos que excedan el límite señalado en la Constitución o la ley y remitirá copia íntegra de los antecedentes al Congreso de Diputadas y Diputados.
@@ -21,19 +21,19 @@ Todos los órganos autónomos se rigen por el principio de paridad. Se promuev
 4. Además, le corresponderá tomar razón de los decretos con fuerza de ley, debiendo representarlos cuando ellos excedan o contravengan la respectiva ley delegatoria.
 5. Respecto de los decretos, resoluciones y otros actos administrativos de entidades territoriales que, de acuerdo con la ley, deban tramitarse por la Contraloría, la toma de razón corresponderá a la respectiva contraloría regional. Los antecedentes que debieran remitirse, en su caso, lo serán a la correspondiente asamblea regional.
 
-### Artículo 353
+### Artículo 353
 
 1. La dirección de la Contraloría General de la República está a cargo de una contralora o un contralor general, quien será designado por la Presidenta o el Presidente de la República, con el acuerdo del Congreso de Diputadas y Diputados y de la Cámara de las Regiones en sesión conjunta, por la mayoría de sus integrantes en ejercicio.
 2. La contralora o el contralor general durará en su cargo un periodo de ocho años, sin posibilidad de reelección.
 3. Un Consejo de la Contraloría, cuya conformación y funcionamiento determinará la ley, aprobará anualmente el programa de fiscalización y auditoría de servicios públicos, determinando los servicios o programas que, a su juicio, deben necesariamente ser incluidos en el referido programa.
 4. Los dictámenes que modifican la jurisprudencia administrativa de la Contraloría serán consultados al Consejo.
 
-### Artículo 354
+### Artículo 354
 
 1. La Contraloría General de la República podrá emitir dictámenes obligatorios para toda autoridad, funcionario o trabajador de cualquier órgano integrante de la Administración del Estado, de las regiones y de las comunas, incluyendo los directivos de empresas públicas o sociedades en las que tenga participación el Estado.
 2. Los órganos de la Administración del Estado, los gobiernos regionales y comunales, los órganos autónomos, las empresas públicas, las sociedades en que el Estado tenga participación, las personas jurídicas que dispongan de recursos fiscales o administren bienes públicos y los demás que defina la ley estarán sujetos a la fiscalización y auditorías de la Contraloría General de la República. La ley regulará el ejercicio de estas potestades fiscalizadoras y auditoras.
 
-### Artículo 355
+### Artículo 355
 
 1. La Contraloría General de la República funcionará desconcentradamente en cada una de las regiones del país mediante contralorías regionales.
 2. La dirección de cada contraloría regional estará a cargo de una contralora o un contralor regional, que designará la contralora o el contralor general de la república.
@@ -41,38 +41,38 @@ Todos los órganos autónomos se rigen por el principio de paridad. Se promuev
 4. La ley determinará las demás atribuciones de las contralorías regionales y regulará su organización y funcionamiento.
 5. Las contralorías regionales controlan la legalidad de la actividad financiera de las entidades territoriales, la gestión y los resultados de la administración de los recursos públicos.
 
-### Artículo 356
+### Artículo 356
 
 Las tesorerías del Estado no podrán efectuar ningún pago sino en virtud de un decreto o resolución expedido por una autoridad competente, en que se exprese la ley o la parte del presupuesto que autorice aquel gasto. Los pagos se efectuarán considerando, además, el orden cronológico establecido en ella y previa refrendación presupuestaria del documento que ordene el pago.
 
 ## Banco Central
 
-### Artículo 357
+### Artículo 357
 
 1. El Banco Central es un órgano autónomo con personalidad jurídica y patrimonio propio, de carácter técnico, encargado de formular y conducir la política monetaria.
 2. La ley regulará su organización, atribuciones y sistemas de control, así como la determinación de instancias de coordinación entre el Banco y el Gobierno.
 
-### Artículo 358
+### Artículo 358
 
 1. Le corresponde en especial al Banco Central, para contribuir al bienestar de la población, velar por la estabilidad de los precios y el normal funcionamiento de los pagos internos y externos.
 2. Para el cumplimiento de su objeto, el Banco Central deberá considerar la estabilidad financiera, la volatilidad cambiaria, la protección del empleo, el cuidado del medioambiente y del patrimonio natural y los principios que señalen la Constitución y la ley.
 3. El Banco, al adoptar sus decisiones, deberá tener presente la orientación general de la política económica del Gobierno.
 
-### Artículo 359
+### Artículo 359
 
 Son atribuciones del Banco Central la regulación de la cantidad de dinero y de crédito en circulación, la ejecución de operaciones de crédito y cambios internacionales, y la potestad para dictar normas en materia monetaria, crediticia, financiera y de cambios internacionales, y las demás que establezca la ley.
 
-### Artículo 360
+### Artículo 360
 
 1. El Banco Central solo podrá efectuar operaciones con instituciones financieras, sean estas públicas o privadas. De ninguna manera podrá otorgarles su garantía ni adquirir documentos emitidos por el Estado, sus órganos o empresas.
 2. Ningún gasto público o préstamo podrá financiarse con créditos directos e indirectos del Banco Central.
 3. Sin perjuicio de lo anterior, en situaciones excepcionales y transitorias en las que así lo requiera la preservación del normal funcionamiento de los pagos internos y externos, el Banco Central podrá comprar durante un período determinado y vender en el mercado secundario abierto, instrumentos de deuda emitidos por el fisco, en conformidad con la ley.
 
-### Artículo 361
+### Artículo 361
 
 El Banco Central rendirá cuenta periódica al Congreso de Diputadas y Diputados y a la Cámara de las Regiones en sesión conjunta, sobre la ejecución de las políticas a su cargo, las medidas y normas generales que adopte en el ejercicio de sus funciones y atribuciones y los demás asuntos que se le soliciten, mediante informes u otros mecanismos que determine la ley.
 
-### Artículo 362
+### Artículo 362
 
 1. La dirección y administración superior del Banco Central estará a cargo de un consejo, al que le corresponderá cumplir las funciones y ejercer las atribuciones que señalen la Constitución y la ley.
 2. El Consejo estará integrado por siete consejeras y consejeros designados por la Presidenta o el Presidente de la República, con el acuerdo del Congreso de Diputadas y Diputados y la Cámara de las Regiones en sesión conjunta, por la mayoría de sus integrantes en ejercicio.
@@ -80,20 +80,20 @@ El Banco Central rendirá cuenta periódica al Congreso de Diputadas y Diputad
 4. Las consejeras y los consejeros del Banco Central deben ser profesionales de comprobada idoneidad y trayectoria en materias relacionadas con las competencias de la institución. La ley determinará sus requisitos, responsabilidades, inhabilidades e incompatibilidades.
 5. La presidenta o el presidente del Consejo, que lo será también del Banco Central, será designado por la Presidenta o el Presidente de la República de entre quienes integren el Consejo, y durará cinco años en este cargo o el tiempo menor que le reste como consejero, pudiendo ser reelegido para un nuevo período.
 
-### Artículo 363
+### Artículo 363
 
 1. Quienes integren el Consejo podrán ser destituidos de sus cargos por resolución de la mayoría de los integrantes del pleno de la Corte Suprema, previo requerimiento de la mayoría de quienes ejerzan como consejeros, de la Presidenta o el Presidente de la República o por la mayoría de diputadas y diputados o de representantes regionales en ejercicio, conforme al procedimiento que establezca la ley.
 2. La remoción solo podrá fundarse en que el consejero haya realizado actos graves en contra de la probidad pública, o haya incurrido en alguna de las prohibiciones o incompatibilidades establecidas en la Constitución o la ley, o haya concurrido con su voto a decisiones que afecten gravemente la consecución del objeto del Banco Central.
 3. La persona destituida no podrá ser designada nuevamente como consejera, ni ser funcionaria del Banco Central o prestarle servicios, sin perjuicio de las demás sanciones que establezca la ley.
 
-### Artículo 364
+### Artículo 364
 
 1. No podrán integrar el Consejo quienes en los doce meses anteriores a su designación hayan participado en la propiedad o ejercido como director, gerente o ejecutivo principal de una empresa bancaria, administradora de fondos, o cualquiera otra que preste servicios de intermediación financiera, sin perjuicio de las demás inhabilidades que establezca la ley.
 2. Una vez que cesen en su cargo, quienes hayan integrado el Consejo tendrán la misma inhabilidad por un período de doce meses.
 
 ## Ministerio Público
 
-### Artículo 365
+### Artículo 365
 
 1. El Ministerio Público es un organismo autónomo y jerarquizado, cuya función es dirigir en forma exclusiva la investigación de los hechos que pudiesen ser constitutivos de delito, los que determinen la participación punible y los que acrediten la inocencia del imputado. Ejerce la acción penal pública en representación de la sociedad, en la forma prevista por la ley.
 2. En dichas funciones debe velar por el respeto y promoción de los derechos humanos, considerando también los intereses de las víctimas, respecto de quienes deberá adoptar todas las medidas que sean necesarias para protegerlas, al igual que a los testigos.
@@ -103,19 +103,19 @@ El Banco Central rendirá cuenta periódica al Congreso de Diputadas y Diputad
 6. El Ministerio Público podrá impartir órdenes directas a las Fuerzas de Orden y Seguridad Pública para el ejercicio de sus funciones, caso en el que podrá, además, participar tanto en la fijación de metas y objetivos como en la evaluación del cumplimiento de todas ellas. La autoridad policial requerida deberá cumplir sin más trámite dichas órdenes y no podrá calificar su fundamento, oportunidad, justicia o legalidad, salvo requerir la exhibición, a menos que esta sea oral, de la autorización judicial.
 7. Las actuaciones que amenacen, priven o perturben al imputado o a terceros del ejercicio de los derechos que esta Constitución asegura requerirán siempre autorización judicial previa y motivada.
 
-### Artículo 366
+### Artículo 366
 
 1. Una ley determinará la organización y las atribuciones del Ministerio Público, señalará las calidades y los requisitos que deberán cumplir quienes se desempeñen como fiscales y sus causales de remoción.
 2. Las autoridades superiores del Ministerio Público deberán siempre fundar las órdenes e instrucciones dirigidas a los fiscales que puedan afectar una investigación o el ejercicio de la acción penal.
 3. Las y los fiscales y funcionarios tendrán un sistema de promoción y ascenso que garantice una carrera que permita fomentar la excelencia técnica y la acumulación de experiencia en las funciones que estos desempeñan. Cesarán en su cargo al cumplir setenta años.
 
-### Artículo 367
+### Artículo 367
 
 1. Existirá una fiscalía regional en cada región del país, sin perjuicio de que la ley pueda establecer más de una por región.
 2. Quienes ejerzan como fiscales regionales deberán haberse desempeñado como fiscales adjuntos durante cinco o más años, no haber ejercido como fiscal regional, haber aprobado cursos de formación especializada y poseer las demás calidades que establezca la ley.
 3. Durarán cuatro años en el cargo y, una vez concluida su labor, podrán retornar a la función que ejercían en el Ministerio Público. No podrán ser reelectos ni postular nuevamente al cargo de fiscal regional.
 
-### Artículo 368
+### Artículo 368
 
 1. La dirección superior del Ministerio Público reside en la o el fiscal nacional, quien durará seis años en el cargo, sin reelección.
 2. Se nombrará en sesión conjunta del Congreso de Diputadas y Diputados y de la Cámara de las Regiones, por la mayoría de sus integrantes en ejercicio a partir de una terna propuesta por la Presidenta o el Presidente de la República, quien contará con la asistencia técnica del Consejo de la Alta Dirección Pública, conforme al procedimiento que determine la ley.
@@ -129,7 +129,7 @@ El Banco Central rendirá cuenta periódica al Congreso de Diputadas y Diputad
     - f) Designar a fiscales adjuntos, a partir de una terna elaborada por el Comité del Ministerio Público.
     - g) Las demás atribuciones que establezcan la Constitución y la ley.
 
-### Artículo 369
+### Artículo 369
 
 1. Existirá un Comité del Ministerio Público, integrado por las y los fiscales regionales y la o el fiscal nacional, quien lo presidirá.
 2. El Comité deberá fijar la política de persecución penal y los criterios de actuación para el cumplimiento de sus objetivos, velando por la transparencia, la objetividad, los intereses de la sociedad y el respeto de los derechos humanos.
@@ -141,50 +141,50 @@ El Banco Central rendirá cuenta periódica al Congreso de Diputadas y Diputad
     - e) Proponer al fiscal nacional las ternas para el nombramiento de los fiscales adjuntos.
     - f) Las demás atribuciones que establezcan la Constitución y la ley.
 
-### Artículo 370
+### Artículo 370
 
 Existirán fiscales adjuntos del Ministerio Público, quienes ejercerán su función en los casos específicos que se les asignen, conforme a lo establecido en la Constitución y las leyes.
 
-### Artículo 371
+### Artículo 371
 
 Quien ejerza como fiscal nacional y quienes se desempeñen como fiscales regionales deberán rendir anualmente una cuenta pública de su gestión. En el primer caso se rendirá la cuenta ante el Congreso de Diputadas y Diputados y la Cámara de las Regiones, en sesión conjunta y, en el segundo, ante la asamblea regional respectiva.
 
-### Artículo 372
+### Artículo 372
 
 1. Quien ejerza como fiscal nacional y los fiscales regionales serán removidos por la Corte Suprema, a requerimiento de la Presidenta o del Presidente de la República, del Congreso de Diputadas y Diputados, o de diez de sus integrantes, por incapacidad, falta grave a la probidad o negligencia manifiesta en el ejercicio de sus funciones. La Corte conocerá del asunto en un pleno especialmente convocado al efecto. Para acordar la remoción deberá reunir el voto conforme de la mayoría de sus integrantes en ejercicio.
 2. La remoción de los fiscales regionales también podrá ser solicitada por quien ejerza como fiscal nacional.
 
 ## Defensoría Penal Pública
 
-### Artículo 373
+### Artículo 373
 
 1. La Defensoría Penal Pública es un organismo autónomo, con personalidad jurídica y patrimonio propio, cuya función es proporcionar defensa penal a los imputados por hechos que pudiesen ser constitutivos de crimen, simple delito o faltas, que deban ser conocidos por los tribunales con competencia en lo penal, desde la primera actuación de la investigación dirigida en su contra y hasta la completa ejecución de la pena que le haya sido impuesta, y que carezcan de defensa letrada.
 2. La Defensoría Penal Pública podrá, en las causas en que intervenga, concurrir ante los organismos internacionales de derechos humanos.
 3. La ley determinará la organización y atribuciones de la Defensoría Penal Pública, debiendo garantizar su independencia externa.
 
-### Artículo 374
+### Artículo 374
 
 1. La función de defensa penal pública será ejercida por defensoras y defensores penales públicos.
 2. Los servicios de defensa jurídica que preste la Defensoría Penal Pública no podrán ser licitados o delegados en abogados particulares, sin perjuicio de la contratación excepcional que se pueda realizar en los casos y forma que establezca la ley.
 
-### Artículo 375
+### Artículo 375
 
 1. La dirección superior de la Defensoría Penal Pública será ejercida por la defensora o el defensor nacional, quien durará seis años en su cargo, sin reelección.
 2. Se nombrará en sesión conjunta del Congreso de Diputadas y Diputados y de la Cámara de las Regiones, por la mayoría de sus integrantes en ejercicio, a partir de una terna propuesta por la Presidenta o el Presidente de la República, conforme al procedimiento y los requisitos que determine la ley.
 
 ## Agencia Nacional de Protección de Datos
 
-### Artículo 376
+### Artículo 376
 
 Existirá un órgano autónomo denominado Agencia Nacional de Protección de Datos, que velará por la promoción y protección de los datos personales, con facultades de normar, investigar, fiscalizar y sancionar a entidades públicas y privadas, el que contará con las atribuciones, la composición y las funciones que determine la ley.
 
 ## Corte Constitucional
 
-### Artículo 377
+### Artículo 377
 
 La Corte Constitucional es un órgano autónomo, técnico y profesional, encargado de ejercer la justicia constitucional para garantizar la supremacía de la Constitución, de acuerdo con los principios de deferencia al órgano legislativo, presunción de constitucionalidad de la ley y búsqueda de una interpretación conforme con la Constitución. Sus resoluciones se fundan únicamente en razones de derecho.
 
-Artículo 378
+### Artículo 378
 
 1. La Corte Constitucional estará conformada por once integrantes, uno de los cuales la presidirá. Será elegido por sus pares y ejercerá sus funciones por dos años.
 2. Las juezas y los jueces de la Corte Constitucional duran nueve años en sus cargos, no son reelegibles y se renuevan por parcialidades cada tres años en la forma que establezca la ley.
@@ -195,18 +195,18 @@ Artículo 378
 4. Quienes postulen al cargo de jueza o juez de la Corte Constitucional deberán ser abogadas o abogados con más de quince años de ejercicio profesional, con reconocida y comprobada competencia e idoneidad profesional o académica y, preferentemente, de distintas especialidades del derecho.
 5. Una ley determinará la organización, el funcionamiento, los procedimientos y fijará la planta, el régimen de remuneraciones y el estatuto del personal de la Corte Constitucional.
 
-### Artículo 379
+### Artículo 379
 
 Quienes integren la Corte Constitucional son independientes de todo otro poder y gozan de inamovilidad. Cesan en sus cargos por haber cumplido su período, por incapacidad legal sobreviniente, por renuncia, por sentencia penal condenatoria, por remoción, por enfermedad incompatible con el ejercicio de la función o por otra causa establecida en la ley.
 
-### Artículo 380
+### Artículo 380
 
 1. El ejercicio del cargo de jueza o juez de la Corte Constitucional es de dedicación exclusiva.
 2. No podrán ser juezas o jueces de la Corte Constitucional quienes se hubiesen desempeñado en cargos de elección popular, quienes hayan desempeñado el cargo de ministra o ministro de Estado u otros cargos de exclusiva confianza del Gobierno, durante los dos años anteriores a su nombramiento. Asimismo, quienes integren la Corte Constitucional tendrán las inhabilidades e incompatibilidades contempladas para las juezas y los jueces del Sistema Nacional de Justicia.
 3. Al terminar su período, y durante los dieciocho meses siguientes, no podrán optar a ningún cargo de elección popular ni de exclusiva confianza de autoridad pública alguna.
 4. La ley determinará las demás incompatibilidades e inhabilidades para el desempeño de este cargo.
 
-### Artículo 381
+### Artículo 381
 
 1. La Corte Constitucional tendrá las siguientes atribuciones:
     - a) Conocer y resolver la inaplicabilidad de un precepto legal cuyos efectos sean contrarios a la Constitución.
@@ -237,7 +237,7 @@ Quienes integren la Corte Constitucional son independientes de todo otro poder y
 1. En el caso de los conflictos de competencia contemplados en las letras h) e i) podrán ser deducidas por cualquiera de las autoridades o tribunales en conflicto.
 2. En lo demás, el procedimiento, el quorum y la legitimación activa para el ejercicio de cada atribución se determinará por la ley.
 
-### Artículo 382
+### Artículo 382
 
 1. Las sentencias de la Corte Constitucional se adoptarán, en sala o en pleno, por la mayoría de sus integrantes, sin perjuicio de las excepciones que establezcan la Constitución o la ley.
 2. La Corte Constitucional solo podrá acoger la inconstitucionalidad o la inaplicabilidad de un precepto cuando no sea posible interpretarlo de modo de evitar efectos inconstitucionales.

--- a/Markdown/11 - Reforma y Reemplazo de la Constitución.md
+++ b/Markdown/11 - Reforma y Reemplazo de la Constitución.md
@@ -8,7 +8,7 @@
 4. Todo proyecto de reforma constitucional deberá señalar expresamente de qué forma se agrega, modifica, reemplaza o deroga una norma de la Constitución.
 5. En lo no previsto en este capítulo, serán aplicables a la tramitación de los proyectos de reforma constitucional las disposiciones que regulan el procedimiento de formación de la ley, debiendo respetarse siempre el quorum señalado en este artículo.
 
-### Artículo 384
+### Artículo 384
 
 1. La Presidenta o el Presidente de la República deberá convocar a referéndum ratificatorio tratándose de proyectos de reforma constitucional aprobados por el Congreso de Diputadas y Diputados y la Cámara de las Regiones, que alteren sustancialmente el régimen político y el período presidencial; el diseño del Congreso de Diputadas y Diputados o de la Cámara de las Regiones y la duración de sus integrantes; la forma de Estado Regional; los principios y los derechos fundamentales; y el capítulo de reforma y reemplazo de la Constitución.
 2. Si el proyecto de reforma constitucional es aprobado por dos tercios de diputadas y diputados y representantes regionales en ejercicio, no será sometido a referéndum ratificatorio.
@@ -17,7 +17,7 @@
 5. La reforma constitucional aprobada por el Congreso de Diputadas y Diputados y la Cámara de las Regiones se entenderá ratificada si alcanza la mayoría de los votos válidamente emitidos en el referéndum.
 6. Es deber del Estado dar adecuada publicidad a la propuesta de reforma que se someterá a referéndum, de acuerdo con la Constitución y la ley.
 
-### Artículo 385
+### Artículo 385
 
 1. Un mínimo equivalente al diez por ciento de la ciudadanía correspondiente al último padrón electoral podrá presentar una propuesta de reforma constitucional para ser votada mediante referéndum nacional conjuntamente con la próxima elección.
 2. Existirá un plazo de ciento ochenta días desde su registro para que la propuesta sea conocida por la ciudadanía y pueda reunir los patrocinios exigidos.
@@ -26,7 +26,7 @@
 
 ## Procedimiento para elaborar una nueva Constitución
 
-### Artículo 386
+### Artículo 386
 
 1. El reemplazo total de la Constitución solo podrá realizarse a través de una Asamblea Constituyente convocada por medio de un referéndum.
 2. El referéndum constituyente podrá ser convocado por iniciativa popular. Un grupo de personas con derecho a sufragio deberá patrocinar la convocatoria con, a lo menos, firmas correspondientes al veinticinco por ciento del padrón electoral que haya sido establecido para la última elección.
@@ -34,13 +34,13 @@
 4. Asimismo, la convocatoria corresponderá al Congreso de Diputadas y Diputados y la Cámara de las Regiones, en sesión conjunta, por medio de una ley aprobada por los dos tercios de sus integrantes en ejercicio.
 5. La convocatoria para la instalación de la Asamblea Constituyente será aprobada si en el referéndum es votada favorablemente por la mayoría de los votos válidamente emitidos.
 
-### Artículo 387
+### Artículo 387
 
 1. La Asamblea Constituyente tendrá como única función la redacción de una propuesta de nueva Constitución. Estará integrada paritariamente y con equidad territorial, con participación en igualdad de condiciones entre independientes e integrantes de partidos políticos y con escaños reservados para pueblos y naciones indígenas.
 2. Una ley regulará su integración; el sistema de elección; su duración, que no será inferior a dieciocho meses; su organización mínima; los mecanismos de participación popular y consulta indígena del proceso, y demás aspectos generales que permitan su instalación y funcionamiento regular.
 3. Una vez redactada y entregada la propuesta de nueva Constitución a la autoridad competente, la Asamblea Constituyente se disolverá de pleno derecho.
 
-### Artículo 388
+### Artículo 388
 
 1. Entregada la propuesta de nueva Constitución, deberá convocarse a un referéndum para su aprobación o rechazo. Para que la propuesta sea aprobada, deberá obtener el voto favorable de más de la mitad de los sufragios válidamente emitidos.
 2. Si la propuesta de nueva Constitución fuera aprobada en el plebiscito, se procederá a su promulgación y correspondiente publicación.


### PR DESCRIPTION
fix: edición de la palabra "Artículo" de capítulos 5 al 11 para tener el mismo encoding de los capítulos 0 al 4
fix: Agregado de ### a Articulo 378

Las palabras Artículo tenían un encoding distinto en los capitulos 5 al 11. Esto hace que las columnas articulo en el dataframe no queden correctos (varios artículos quedaban asignado al artículo 164 y los subtítulos Artículo no se identifican como tal)

**Dataframe con error**
![dataframe-con-error](https://user-images.githubusercontent.com/51895235/184973835-930fa0b4-ec0c-4bb9-9d7a-50632b2929cf.png)

**Dataframe correcto**
![dataframe-correcto](https://user-images.githubusercontent.com/51895235/184973854-b3f0d1eb-012d-411c-89f0-b8facd88ed2d.png)
